### PR TITLE
Add URL output for Artconomy journals.

### DIFF
--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -192,7 +192,7 @@ export class Artconomy extends Website {
     };
 
     this.checkCancelled(cancellationToken);
-    const postResponse = await Http.post<string>(
+    const postResponse = await Http.post<{id: number}>(
       `${this.BASE_URL}/api/profiles/v1/account/${username}/journals/`,
       data.part.accountId,
       {
@@ -201,7 +201,7 @@ export class Artconomy extends Website {
       },
     );
     this.verifyResponse(postResponse);
-    return this.createPostResponse({});
+    return this.createPostResponse({ source: `${this.BASE_URL}/profile/${username}/journals/${postResponse.body.id}` });
   }
 
   parseTags(tags: string[]) {


### PR DESCRIPTION
This pull request adds journal URL logging to the Artconomy module. Previously the post would succeed but not give the user a URL to check for output.

**Testing instructions**:

1. Create a new journal post on Artconomy
2. Check the log output and find the URL is present.

**Reviewers**
- [ ] @mvdicarlo 