### PR TITLE
Fix ac markup tag expansion.

### DIFF
--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -43,7 +43,7 @@ export class Artconomy extends Website {
   usernameShortcuts: UsernameShortcut[] = [
     {
       key: 'ac',
-      url: 'https://artconomy.com/$1',
+      url: 'https://artconomy.com/profile/$1/about',
     },
   ];
 


### PR DESCRIPTION
This pull request corrects the expansion of Artconomy profile URLs via the `ac` markup tag.

**Testing instructions**:

1. Create a new file post.
2. In the description of the file post, add in an ac user tag, like `{ac:Fox}`
3. Post the file
4. Visit the post in your browser and verify the link visits the profile.

**Reviewers**
- [ ] @mvdicarlo 