### PR TITLE
fix: Update Artconomy endpoints to match current schema.

### DIFF
--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -50,7 +50,7 @@ export class Artconomy extends Website {
   async checkLoginStatus(data: UserAccountEntity): Promise<LoginResponse> {
     const status: LoginResponse = { loggedIn: false, username: null };
     const authCheck = await Http.get<any>(
-      `${this.BASE_URL}/api/profiles/v1/data/requester/`,
+      `${this.BASE_URL}/api/profiles/data/requester/`,
       data._id,
       {
         requestOptions: {
@@ -118,7 +118,7 @@ export class Artconomy extends Website {
     const options = this.requestOptions(data);
     this.checkCancelled(cancellationToken);
     let upload = await Http.post<{ id: string }>(
-      `${this.BASE_URL}/api/lib/v1/asset/`,
+      `${this.BASE_URL}/api/lib/asset/`,
       data.part.accountId,
       {
         ...options,
@@ -132,7 +132,7 @@ export class Artconomy extends Website {
     let thumbnailAsset: null | string = null;
     if (data.thumbnail) {
       upload = await Http.post<{ id: string }>(
-        `${this.BASE_URL}/api/lib/v1/asset/`,
+        `${this.BASE_URL}/api/lib/asset/`,
         data.part.accountId,
         {
           ...options,
@@ -161,7 +161,7 @@ export class Artconomy extends Website {
 
     this.checkCancelled(cancellationToken);
     const post = await Http.post<any>(
-      `${this.BASE_URL}/api/profiles/v1/account/${username}/submissions/`,
+      `${this.BASE_URL}/api/profiles/account/${username}/submissions/`,
       data.part.accountId,
       {
         ...options,
@@ -200,7 +200,7 @@ export class Artconomy extends Website {
 
     this.checkCancelled(cancellationToken);
     const postResponse = await Http.post<{id: number}>(
-      `${this.BASE_URL}/api/profiles/v1/account/${username}/journals/`,
+      `${this.BASE_URL}/api/profiles/account/${username}/journals/`,
       data.part.accountId,
       {
         ...options,


### PR DESCRIPTION
This PR updates the endpoints to match the revised schema for Artconomy's API. We're dropping the version markers since we're not actually using versioning so it creates a broken expectation that the API is not ever evolving. Some future versioning schema may be imposed, but as active practice is constant evolution, no version promises should be made.

**Testing instructions**:

1. Step by step manual setup/testing/verification instructions for your reviewers go here. Make sure you (the author) have already manually tested it using the same steps.
2. Step 2

**Author notes and concerns**:

1. I was having a hard time getting the develop branch to run. I may have just forgotten how-- so I haven't managed to test this myself.
2. The changes on Artconomy's end are already live. I've got a shim in place to allow PostyBirb to keep working for a while until this has been live and people have had a bit to upgrade. Please keep me posted on when you've released these changes so I can decide when to pull the shim code.

**Reviewers**
- [ ] @mvdicarlo 