### PR TITLE
docs: Add basic development setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ This is where all posting magic happens.
 ## [UI](/ui)
 React code that handles UI of the application displayed in the desktop application.
 
+## Configuring for local development
+
+To set up a local copy of PostyBirb for development:
+
+1. clone this repository and `cd` into it.
+2. `npm install` to install the base requirements.
+3. For the `commons`, `ui`, and `electron-app` directories, cd into each and run `npm install`. Be sure to start with commons first.
+
+Then, from the base directory again, run:
+
+```bash
+npm run make && npm run start --prefix electron-app
+```
+
+This will build and run the application. After making changes, close out of the app and run the above command again to rebuild and run with your changes.
+
 ## Contribution Guide
 _Pending_
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -75,6 +75,7 @@
     "postcss-cli": "^6.1.3",
     "prettier": "^1.18.2",
     "rimraf": "^3.0.2",
+    "shx": "^0.3.4",
     "tailwindcss": "^1.9.6"
   }
 }


### PR DESCRIPTION
This PR adds in some basic instructions for starting on development. These are the commands I currently use to work on the project.

**Author notes and concerns**:

I'm not sure this is the best workflow available, but it works for me. I've tried using `npm run start:dev` in the `electron-app` directory but it does not seem to work.