### PR TITLE
fix: Artconomy minimum tag count.

### DIFF
--- a/ui/src/websites/artconomy/Artconomy.tsx
+++ b/ui/src/websites/artconomy/Artconomy.tsx
@@ -11,6 +11,7 @@ import { WebsiteSectionProps } from '../form-sections/website-form-section.inter
 import GenericFileSubmissionSection from '../generic/GenericFileSubmissionSection';
 import { WebsiteImpl } from '../website.base';
 import GenericSubmissionSection from '../generic/GenericSubmissionSection';
+import { artconomyTagSearchProvider } from './providers';
 
 export class Artconomy extends WebsiteImpl {
   internalName: string = 'Artconomy';
@@ -21,6 +22,11 @@ export class Artconomy extends WebsiteImpl {
 
   FileSubmissionForm = (props: WebsiteSectionProps<FileSubmission, ArtconomyFileOptions>) => (
     <ArtconomyFileSubmissionForm
+      tagOptions={{
+        show: true,
+        searchProvider: artconomyTagSearchProvider,
+        options: { minTags: 5, mode: 'count' }
+      }}
       ratingOptions={{
         show: true,
         ratings: [
@@ -50,7 +56,11 @@ export class Artconomy extends WebsiteImpl {
   NotificationSubmissionForm = (props: WebsiteSectionProps<Submission, DefaultOptions>) => (
     <GenericSubmissionSection
       key={props.part.accountId}
-      tagOptions={{ show: false }}
+      tagOptions={{
+        show: true,
+        searchProvider: artconomyTagSearchProvider,
+        options: { minTags: 5, mode: 'count' }
+      }}
       ratingOptions={{ show: false }}
       {...props}
     />

--- a/ui/src/websites/artconomy/providers.tsx
+++ b/ui/src/websites/artconomy/providers.tsx
@@ -1,0 +1,14 @@
+import Axios from 'axios';
+
+export const artconomyTagSearchProvider = (value: string) => {
+  return Axios.get('https://artconomy.com/api/profiles/search/tag/?', {
+    params: {
+      q: value
+    }
+  })
+    .then(({ data }) => data || [])
+    .catch(err => {
+      console.error(err);
+      return [];
+    });
+};

--- a/ui/src/websites/e621/e621.tsx
+++ b/ui/src/websites/e621/e621.tsx
@@ -1,5 +1,4 @@
 import { Form, Input } from 'antd';
-import Axios from 'axios';
 import _ from 'lodash';
 import { e621FileOptions, FileSubmission, SubmissionPart } from 'postybirb-commons';
 import React from 'react';
@@ -8,6 +7,7 @@ import GenericFileSubmissionSection from '../generic/GenericFileSubmissionSectio
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { WebsiteImpl } from '../website.base';
 import E621Login from './e621Login';
+import { e621TagSearchProvider } from './providers';
 
 export class e621 extends WebsiteImpl {
   internalName: string = 'e621';
@@ -23,19 +23,7 @@ export class e621 extends WebsiteImpl {
       hideThumbnailOptions={true}
       tagOptions={{
         show: true,
-        searchProvider: (value: string) => {
-          return Axios.get('https://e621.net/tags/autocomplete.json?', {
-            params: {
-              expiry: '7',
-              'search[name_matches]': value
-            }
-          })
-            .then(({ data }) => (data || []).map(d => d.name))
-            .catch(err => {
-              console.error(err);
-              return [];
-            });
-        }
+        searchProvider: e621TagSearchProvider
       }}
       key={props.part.accountId}
       {...props}

--- a/ui/src/websites/e621/providers.tsx
+++ b/ui/src/websites/e621/providers.tsx
@@ -1,0 +1,15 @@
+import Axios from 'axios';
+
+export const e621TagSearchProvider = (value: string) => {
+  return Axios.get('https://e621.net/tags/autocomplete.json?', {
+    params: {
+      expiry: '7',
+      'search[name_matches]': value
+    }
+  })
+    .then(({ data }) => (data || []).map(d => d.name))
+    .catch(err => {
+      console.error(err);
+      return [];
+    });
+};


### PR DESCRIPTION
This PR adds autocomplete for Artconomy's tags, and requires a minimum of 5 tags to match the backend, which was recently updated to require minimum tagging requirements.

**Testing instructions**:

1. Create a new file and ready it for submission on Artconomy
2. Start to type a tag name
3. Observe autocompletion
4. Observe notice of minimum 5 tags