### PR TITLE
feat: Default tag search provider

### DIFF
--- a/commons/src/interfaces/settings/settings.interface.ts
+++ b/commons/src/interfaces/settings/settings.interface.ts
@@ -1,3 +1,6 @@
+// Cannot use an empty string value here-- the data handling code does not like it.
+type TagSearchProviders = 'none' | 'artconomy' | 'e621'
+
 export interface Settings {
   advertise: boolean;
   emptyQueueOnFailedPost: boolean;
@@ -10,4 +13,5 @@ export interface Settings {
   maxJPEGQualityCompression: number;
   maxJPEGSizeCompression: number;
   silentNotification: boolean;
+  defaultTagSearchProvider: TagSearchProviders;
 }

--- a/electron-app/src/app/settings.ts
+++ b/electron-app/src/app/settings.ts
@@ -11,7 +11,7 @@ const settingsPath = path.join(global.BASE_DIRECTORY, 'data', 'settings.json');
 fs.ensureFileSync(settingsPath);
 const adapter = new FileSync(settingsPath);
 const settings = low(adapter);
-const settingDefauls: Settings = {
+const settingDefaults: Settings = {
   advertise: true,
   emptyQueueOnFailedPost: true,
   postRetries: 0,
@@ -23,8 +23,9 @@ const settingDefauls: Settings = {
   maxJPEGQualityCompression: 15,
   maxJPEGSizeCompression: 50,
   silentNotification: false,
+  defaultTagSearchProvider: 'none',
 };
-settings.defaults(settingDefauls).write();
+settings.defaults(settingDefaults).write();
 
 if (!settings.getState().useHardwareAcceleration || util.isLinux()) {
   console.log('Hardware acceleration disabled');

--- a/electron-app/src/main.ts
+++ b/electron-app/src/main.ts
@@ -14,6 +14,7 @@ import * as WindowStateKeeper from 'electron-window-state';
 import { enableSleep } from './app/power-save';
 import * as util from './app/utils';
 import { initialize as initializeRemote, enable as enableRemote } from '@electron/remote/main';
+import { session } from 'electron';
 
 initializeRemote();
 
@@ -104,6 +105,15 @@ async function initialize() {
   if (!hasLock) {
     return;
   }
+  const ses = session.fromPartition('persist:name');
+  const userAgent = `PostyBirb/${
+    app.getVersion()
+  } (by mvdicarlo on GitHub) ${ses.getUserAgent()}`;
+
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = userAgent;
+    callback({ cancel: false, requestHeaders: details.requestHeaders });
+  });
 
   let shouldDisplayWindow = true;
   if (!initializedOnce) {

--- a/ui/src/stores/settings.store.ts
+++ b/ui/src/stores/settings.store.ts
@@ -17,6 +17,7 @@ export class SettingsStore {
     maxJPEGQualityCompression: 10,
     maxJPEGSizeCompression: 30,
     silentNotification: false,
+    defaultTagSearchProvider: 'none'
   };
 
   constructor() {

--- a/ui/src/views/settings/SettingsView.tsx
+++ b/ui/src/views/settings/SettingsView.tsx
@@ -28,7 +28,12 @@ interface Props {
 @observer
 export default class SettingsView extends React.Component<Props> {
   private updateSetting(key: keyof Settings, value: any) {
-    if (value === undefined || value === '' || value === null) return;
+    if (
+      value === undefined ||
+      (value === '' && key !== 'defaultTagSearchProvider') ||
+      value === null
+    )
+      return;
     if (value === this.props.settingsStore!.settings[key]) return;
     SettingsService.updateSetting(key, value);
   }
@@ -79,6 +84,20 @@ export default class SettingsView extends React.Component<Props> {
                     this.updateSetting('postRetries', Math.min(2, Math.max(0, Number(value))))
                   }
                 />
+              </Tooltip>
+            </Form.Item>
+            <Form.Item label="Default tagging search provider">
+              <Tooltip title="When creating a new post, autocomplete tags from this provider.">
+                <Radio.Group
+                  value={settings.defaultTagSearchProvider}
+                  onChange={event =>
+                    this.updateSetting('defaultTagSearchProvider', event.target.value)
+                  }
+                >
+                  <Radio.Button value="none">Do not autocomplete</Radio.Button>
+                  <Radio.Button value="artconomy">Artconomy</Radio.Button>
+                  <Radio.Button value="e621">e621</Radio.Button>
+                </Radio.Group>
               </Tooltip>
             </Form.Item>
           </Collapse.Panel>

--- a/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
+++ b/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+import { inject } from "mobx-react";
 import { SubmissionPart } from 'postybirb-commons';
 import { SubmissionSectionProps } from '../interfaces/submission-section.interface';
 import TagInput from '../form-components/TagInput';
@@ -9,7 +10,16 @@ import { Submission } from 'postybirb-commons';
 import { DefaultOptions } from 'postybirb-commons';
 import SectionProblems from './SectionProblems';
 import { SubmissionRating } from 'postybirb-commons';
+import { artconomyTagSearchProvider } from '../../../../websites/artconomy/providers';
+import { e621TagSearchProvider } from '../../../../websites/e621/providers';
 
+const SEARCH_PROVIDERS = {
+  none: undefined,
+  artconomy: artconomyTagSearchProvider,
+  e621: e621TagSearchProvider
+};
+
+@inject('settingsStore')
 export default class DefaultFormSection extends React.Component<
   SubmissionSectionProps<Submission, DefaultOptions>
 > {
@@ -33,6 +43,7 @@ export default class DefaultFormSection extends React.Component<
 
   render() {
     const { data } = this.props.part;
+    const settings = this.props.settingsStore!.settings
     return (
       <div>
         <SectionProblems problems={this.props.problems} />
@@ -55,6 +66,9 @@ export default class DefaultFormSection extends React.Component<
           onChange={this.handleTagChange.bind(this)}
           defaultValue={data.tags}
           label="Tags"
+          searchProvider={
+            SEARCH_PROVIDERS[settings.defaultTagSearchProvider || 'none']
+          }
           hideExtend={true}
         />
         <DescriptionInput

--- a/ui/src/views/submissions/submission-forms/interfaces/submission-section.interface.ts
+++ b/ui/src/views/submissions/submission-forms/interfaces/submission-section.interface.ts
@@ -2,6 +2,7 @@ import { SubmissionPart } from 'postybirb-commons';
 import { Submission } from 'postybirb-commons';
 import { DefaultOptions } from 'postybirb-commons';
 import { Problem } from 'postybirb-commons';
+import { SettingsStore } from '../../../../stores/settings.store';
 
 export interface SubmissionSectionProps<T extends Submission, K extends DefaultOptions> {
   onUpdate: (update: SubmissionPart<K>) => void;
@@ -9,4 +10,5 @@ export interface SubmissionSectionProps<T extends Submission, K extends DefaultO
   part: SubmissionPart<K>;
   problems?: Problem;
   submission: T;
+  settingsStore?: SettingsStore;
 }


### PR DESCRIPTION
This PR adds a new setting to select a default tag search provider, allowing the main tag field to query available supported providers for their tag listings.

**Dependencies**: https://github.com/mvdicarlo/postybirb-plus/pull/161

**Screenshots**: 

![image](https://user-images.githubusercontent.com/1099483/234670501-3aa0099b-bb5b-4c7e-887d-45a496adc2c3.png)

**Testing instructions**:

1. Create a new file submission
2. Observe no autocompletion with the default setting selected.
3. Enter settings. Under Posting, select the Artconomy provider.
4. Observe autocompletion from Artconomy in the main tag field.
5. Enter settings. Under Posting, select the e621 provider.
6. Observe autocompletion from e621 in the main tag field.

**Author notes and concerns**:

The default is no provider. It might be better to set a default-- likely e621 because their tag library is better, more consistent, and more comprehensive than ours. However I'm not sure how e621 feels about their tag endpoint being queried when it may or may not be used to post to their community.