### PR TITLE
Allow adding content warnings to Itaku posts

### DIFF
--- a/commons/src/interfaces/websites/itaku/itaku.file.options.interface.ts
+++ b/commons/src/interfaces/websites/itaku/itaku.file.options.interface.ts
@@ -4,4 +4,5 @@ export interface ItakuFileOptions extends DefaultFileOptions {
   folders: string[];
   visibility: string;
   shareOnFeed: boolean;
+  spoilerText?: string;
 }

--- a/commons/src/interfaces/websites/itaku/itaku.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/itaku/itaku.notification.options.interface.ts
@@ -3,4 +3,5 @@ import { DefaultOptions } from '../../submission/default-options.interface';
 export interface ItakuNotificationOptions extends DefaultOptions {
   folders: string[];
   visibility: string;
+  spoilerText?: string;
 }

--- a/commons/src/websites/itaku/itaku.file.options.ts
+++ b/commons/src/websites/itaku/itaku.file.options.ts
@@ -21,6 +21,11 @@ export class ItakuFileOptionsEntity extends DefaultFileOptionsEntity implements 
   @DefaultValue(true)
   shareOnFeed!: boolean;
 
+  @Expose()
+  @IsString()
+  @IsOptional()
+  spoilerText?: string;
+
   constructor(entity?: Partial<ItakuFileOptions>) {
     super(entity as DefaultFileOptions);
   }

--- a/commons/src/websites/itaku/itaku.notification.options.ts
+++ b/commons/src/websites/itaku/itaku.notification.options.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsArray, IsString } from 'class-validator';
+import { IsArray, IsString, IsOptional } from 'class-validator';
 import { DefaultOptions } from '../../interfaces/submission/default-options.interface';
 import { ItakuNotificationOptions } from '../../interfaces/websites/itaku/itaku.notification.options.interface';
 import { DefaultValue } from '../../models/decorators/default-value.decorator';
@@ -16,6 +16,11 @@ export class ItakuNotificationOptionsEntity extends DefaultOptionsEntity
   @IsString()
   @DefaultValue('PUBLIC')
   visibility!: string;
+
+  @Expose()
+  @IsString()
+  @IsOptional()
+  spoilerText?: string;
 
   constructor(entity?: Partial<ItakuNotificationOptions>) {
     super(entity as DefaultOptions);

--- a/electron-app/src/server/websites/itaku/itaku.service.ts
+++ b/electron-app/src/server/websites/itaku/itaku.service.ts
@@ -119,9 +119,8 @@ export class Itaku extends Website {
       case SubmissionRating.MATURE:
         return 'Questionable';
       case SubmissionRating.ADULT:
-        return 'NSFW';
       case SubmissionRating.EXTREME:
-        return 'Extreme';
+        return 'NSFW';
     }
   }
 

--- a/electron-app/src/server/websites/itaku/itaku.service.ts
+++ b/electron-app/src/server/websites/itaku/itaku.service.ts
@@ -141,6 +141,10 @@ export class Itaku extends Website {
       add_to_feed: `${data.options.shareOnFeed}`,
     };
 
+    if (data.options.spoilerText) {
+      postData.content_warning = data.options.spoilerText;
+    }
+
     if (data.primary.type === FileSubmissionType.IMAGE) {
       postData.image = data.primary.file;
     } else {
@@ -180,7 +184,7 @@ export class Itaku extends Website {
     data: PostData<Submission, ItakuNotificationOptions>,
     accountData: any,
   ): Promise<PostResponse> {
-    const postData = {
+    const postData: any = {
       title: data.title,
       content: data.description,
       folders: data.options.folders,
@@ -189,6 +193,10 @@ export class Itaku extends Website {
       tags: data.tags.map((tag) => ({ name: tag })),
       visibility: data.options.visibility,
     };
+
+    if (data.options.spoilerText) {
+      postData.content_warning = data.options.spoilerText;
+    }
 
     this.checkCancelled(cancellationToken);
 

--- a/ui/src/websites/itaku/Itaku.tsx
+++ b/ui/src/websites/itaku/Itaku.tsx
@@ -1,4 +1,4 @@
-import { Form, Select, Checkbox } from 'antd';
+import { Form, Select, Checkbox, Input } from 'antd';
 import {
   FileSubmission,
   SubmissionRating,
@@ -198,7 +198,14 @@ export class ItakuFileSubmissionForm extends GenericFileSubmissionSection<ItakuF
         >
           Share on feed
         </Checkbox>
-      </div>
+      </div>,
+      <Form.Item label="Content Warning">
+        <Input
+          value={data.spoilerText}
+          onChange={this.handleValueChange.bind(this, 'spoilerText')}
+          maxLength={30}
+        />
+      </Form.Item>
     );
     return elements;
   }

--- a/ui/src/websites/itaku/Itaku.tsx
+++ b/ui/src/websites/itaku/Itaku.tsx
@@ -45,10 +45,6 @@ export class Itaku extends WebsiteImpl {
           {
             value: SubmissionRating.ADULT,
             name: 'NSFW'
-          },
-          {
-            value: SubmissionRating.EXTREME,
-            name: 'NSFL'
           }
         ]
       }}
@@ -79,10 +75,6 @@ export class Itaku extends WebsiteImpl {
           {
             value: SubmissionRating.ADULT,
             name: 'NSFW'
-          },
-          {
-            value: SubmissionRating.EXTREME,
-            name: 'Extreme'
           }
         ]
       }}


### PR DESCRIPTION
Analogous to other spoiler text implementations. Ancillary work during implementation of #170.

Edit: also removes the NSFL/Extreme rating category, because that got removed when content warnings were added to the site. Thanks ArgonVile for pointing that out.