### PR TITLE
Allow all combinations of Inkbunny ratings

### DIFF
--- a/electron-app/src/server/websites/inkbunny/inkbunny.service.ts
+++ b/electron-app/src/server/websites/inkbunny/inkbunny.service.ts
@@ -158,10 +158,12 @@ export class Inkbunny extends Website {
       keywords: this.formatTags(data.tags),
     };
 
-    const rating = this.getRating(data.rating);
-    if (rating !== '0') {
+    const ratings = this.getRating(data.rating);
+    if (ratings !== '0') {
       // when not general
-      editForm[`tag[${rating}]`] = 'yes';
+      for(const rating of ratings.split(',')) {
+        editForm[`tag[${rating}]`] = 'yes';
+      }
     }
 
     const { options } = data;

--- a/ui/src/websites/inkbunny/Inkbunny.tsx
+++ b/ui/src/websites/inkbunny/Inkbunny.tsx
@@ -23,20 +23,36 @@ export class Inkbunny extends WebsiteImpl {
         ratings: [
           {
             value: '2',
-            name: 'Nudity - Nonsexual'
+            name: 'Nudity'
           },
           {
             value: '3',
-            name: 'Violence - Mild'
+            name: 'Violence'
+          },
+          {
+            value: '2,3',
+            name: 'Nudity + Violence',
           },
           {
             value: '4',
-            name: 'Sexual Themes - Erotic'
+            name: 'Sexual'
           },
           {
             value: '5',
-            name: 'Strong Violence'
-          }
+            name: 'Brutal'
+          },
+          {
+            value: '2,5',
+            name: 'Nudity + Brutal',
+          },
+          {
+            value: '3,4',
+            name: 'Sexual + Violent',
+          },
+          {
+            value: '4,5',
+            name: 'Sexual + Brutal',
+          },
         ]
       }}
       key={props.part.accountId}


### PR DESCRIPTION
Since you might have a submission that is both sexual and violent or something. To fit with the one-dimensional idea of ratings, this now offers all combinations as separate buttons. It could be done as checkboxes instead too, but this way works fine without reinventing the whole ratings concept in multiple dimensions.

Names got shortened a bit to avoid buttons spilling to the next line quite as easily.

More ancillary work during implementation of #170.