### PR TITLE
Don't pre-select blank default template part

### DIFF
--- a/ui/src/views/submissions/submission-forms/form-components/ImportDataSelect.tsx
+++ b/ui/src/views/submissions/submission-forms/form-components/ImportDataSelect.tsx
@@ -8,6 +8,7 @@ import { TreeNode } from 'antd/lib/tree-select';
 import { WebsiteRegistry } from '../../../../websites/website-registry';
 import SubmissionTemplateSelect from '../../submission-template-select/SubmissionTemplateSelect';
 import { SubmissionType } from 'postybirb-commons';
+import { DefaultOptions } from 'postybirb-commons';
 
 interface Props {
   className?: string;
@@ -101,6 +102,22 @@ export default class ImportDataSelect extends React.Component<Props, State> {
     return [];
   };
 
+  shouldSelectPart = (part: SubmissionPart<any>): boolean => {
+    // Don't pre-select the default section when it's empty. The user probably
+    // doesn't want their defaults clobbered with nothingness.
+    if (part.isDefault) {
+      const defaultOptions: DefaultOptions = part.data;
+      return !!(
+        defaultOptions.title?.trim() ||
+        defaultOptions.tags?.value?.length ||
+        defaultOptions.description?.value?.trim() ||
+        !_.isNil(defaultOptions.rating)
+      );
+    } else {
+      return true;
+    }
+  };
+
   render() {
     const title = this.props.label || 'Import';
     return (
@@ -127,7 +144,11 @@ export default class ImportDataSelect extends React.Component<Props, State> {
               onSelect={(id, type, parts) => {
                 this.setState({
                   selected: parts,
-                  selectedFields: parts ? Object.values(parts).map(p => p.accountId) : []
+                  selectedFields: parts
+                    ? Object.values(parts)
+                        .filter(this.shouldSelectPart)
+                        .map(p => p.accountId)
+                    : []
                 });
               }}
             />


### PR DESCRIPTION
If the default part of a template is completely empty, the user probably doesn't want to use it to clobber their inputs with nothingness. So now a blank default part is deselected by default when applying a template to a submission, which seems like the more intuitive behavior. If the user really wants the clobbering behavior, they can manually check it.

An even cooler implementation would probably let a user pick which pieces of a template are supposed to apply to avoid this kind of coarse guesswork, but this works okay without totally reimagining templates.