### PR TITLE
Multiple Submission Import

### DIFF
--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -25,6 +25,7 @@ export * from './interfaces/submission/post-response.interface';
 export * from './interfaces/submission/post-status.interface';
 export * from './interfaces/submission/problems.interface';
 export * from './interfaces/submission/submission-create.interface';
+export * from './interfaces/submission/submission-import.interface';
 export * from './interfaces/submission/submission-log.interface';
 export * from './interfaces/submission/submission-overwrite.interface';
 export * from './interfaces/submission/submission-package.interface';

--- a/commons/src/interfaces/submission/submission-create.interface.ts
+++ b/commons/src/interfaces/submission/submission-create.interface.ts
@@ -7,4 +7,6 @@ export interface SubmissionCreate {
   path?: string;
   file?: UploadedFile;
   parts?: string;
+  thumbnailPath?: string;
+  thumbnailFile?: UploadedFile;
 }

--- a/commons/src/interfaces/submission/submission-import.interface.ts
+++ b/commons/src/interfaces/submission/submission-import.interface.ts
@@ -1,0 +1,8 @@
+export interface SubmissionImport {
+  path: string;
+}
+
+export interface SubmissionImportResult {
+  importType: string|null;
+  submissionCount: number;
+}

--- a/electron-app/src/app/preload.ts
+++ b/electron-app/src/app/preload.ts
@@ -1,5 +1,5 @@
 /* tslint:disable: no-console no-var-requires variable-name */
-import { clipboard, shell, session, app, getCurrentWindow } from '@electron/remote';
+import { clipboard, dialog, shell, session, app, getCurrentWindow } from '@electron/remote';
 
 // Authorizers
 const Tumblr = require('./authorizers/tumblr.auth');
@@ -30,6 +30,11 @@ process.once('loaded', () => {
         lastModified: Date.now(),
         type: 'image/png',
       });
+    },
+  },
+  dialog: {
+    showOpenDialog(options) {
+      return dialog.showOpenDialog(getCurrentWindow(), options || {});
     },
   },
   session: {

--- a/electron-app/src/server/submission/models/submission-create.model.ts
+++ b/electron-app/src/server/submission/models/submission-create.model.ts
@@ -23,6 +23,14 @@ export default class SubmissionCreateModel implements SubmissionCreate {
   @IsOptional()
   parts: string; // Array<SubmissionPart<any>>;
 
+  @IsObject()
+  @IsOptional()
+  thumbnailFile: UploadedFile;
+
+  @IsString()
+  @IsOptional()
+  thumbnailPath: string;
+
   constructor(partial?: Partial<SubmissionCreateModel>) {
     Object.assign(this, partial);
   }

--- a/electron-app/src/server/submission/models/submission-import.model.ts
+++ b/electron-app/src/server/submission/models/submission-import.model.ts
@@ -1,0 +1,11 @@
+import { IsString } from 'class-validator';
+import { SubmissionImport } from 'postybirb-commons';
+
+export default class SubmissionImportModel implements SubmissionImport {
+  @IsString()
+  path: string;
+
+  constructor(partial?: Partial<SubmissionImportModel>) {
+    Object.assign(this, partial);
+  }
+}

--- a/electron-app/src/server/submission/submission-importer/importers/activity-pub-importer.ts
+++ b/electron-app/src/server/submission/submission-importer/importers/activity-pub-importer.ts
@@ -1,0 +1,261 @@
+import * as _ from 'lodash';
+import * as fs from 'fs-extra';
+import { DirectoryEntry, Importer } from './importer';
+import { Element, Node } from 'domhandler';
+import { FileSubmissionType } from 'postybirb-commons';
+import { Logger } from '@nestjs/common';
+import { SubmissionImporterService } from '../submission-importer.service';
+import { SubmissionRating } from 'postybirb-commons';
+import { getSubmissionType } from '../../file-submission/helpers/file-submission-type.helper';
+import { join } from 'path';
+
+interface ActivityPubImportAttachment {
+  path: string;
+  altText: string;
+}
+
+interface ActivityPubImport {
+  id: string;
+  content: string;
+  sensitive: boolean;
+  summary: string;
+  published: string;
+  attachments: ActivityPubImportAttachment[];
+  tags: string[];
+}
+
+interface ActivityPubOutboxItem {
+  type: string;
+  to?: string[];
+  cc?: string[];
+  object?: {
+    type: string;
+    id: string;
+    published: string;
+    summary?: string;
+    sensitive?: boolean;
+    content?: string;
+    attachment?: {
+      type: string;
+      mediaType?: string;
+      url?: string;
+      name?: string;
+    }[];
+    tag?: {
+      type: string;
+      name?: string;
+    }[];
+  };
+}
+
+interface ActivityPubOutbox {
+  orderedItems?: ActivityPubOutboxItem[];
+}
+
+function looksLikeSubmission(mimetype: string, name: string): boolean {
+  return getSubmissionType(mimetype, name) !== FileSubmissionType.UNKNOWN;
+}
+
+// Imports dumps from ActivityPub exports, such as produced by Mastodon
+export class ActivityPubImporter extends Importer {
+  private readonly logger = new Logger(ActivityPubImporter.name);
+
+  constructor(service: SubmissionImporterService) {
+    super(service);
+  }
+
+  override getName(): string {
+    return ActivityPubImporter.name;
+  }
+
+  override getDisplayName(): string {
+    return 'ActivityPub export';
+  }
+
+  override identify(tree: DirectoryEntry): boolean {
+    // Technically we just need an outbox.json, but there's always going to be
+    // an actor.json too, so we use that as circumstantial evidence.
+    let hasActorJson = false;
+    let hasOutboxJson = false;
+    for (const { type, name } of tree.entries) {
+      if (type === 'file') {
+        if (name === 'actor.json') {
+          hasActorJson = true;
+        } else if (name === 'outbox.json') {
+          hasOutboxJson = true;
+        }
+      }
+    }
+    return hasActorJson && hasOutboxJson;
+  }
+
+  override async extract(tree: DirectoryEntry): Promise<number> {
+    const imports: ActivityPubImport[] = [];
+    const outbox = await this.parseOutboxJson(tree);
+    for (const item of outbox.orderedItems || []) {
+      const imp = this.extractItem(tree, item);
+      if (imp) {
+        imports.push(imp);
+      }
+    }
+
+    const count = imports.length;
+    this.tryExtractImports(imports).then((successes) => {
+      this.logger.debug(`${successes}/${count} imported`, 'Imported Finished');
+      this.showCompletedNotification(successes, count);
+    });
+    return count;
+  }
+
+  private async parseOutboxJson({ entries }: DirectoryEntry): Promise<ActivityPubOutbox> {
+    for (const entry of entries) {
+      if (entry.type === 'file' && entry.name === 'outbox.json') {
+        const text = await fs.readFile(entry.path, 'utf-8');
+        return JSON.parse(text);
+      }
+    }
+    throw Error('No outbox.json found');
+  }
+
+  private extractItem(
+    { path }: DirectoryEntry,
+    item: ActivityPubOutboxItem,
+  ): ActivityPubImport | null {
+    if (item?.type !== 'Create') {
+      return null;
+    }
+
+    if(this.looksLikeDirectMessage(item)) {
+      return null;
+    }
+
+    const object = item.object;
+    if (object?.type !== 'Note' || !object.attachment) {
+      return null;
+    }
+
+    const imp: ActivityPubImport = {
+      id: object.id || '',
+      published: object.published || '',
+      content: object.content || '',
+      sensitive: !!object.sensitive,
+      summary: object.summary || '',
+      attachments: [],
+      tags: [],
+    };
+
+    for (const attachment of object.attachment || []) {
+      if (attachment?.type === 'Document' && attachment.url) {
+        const attachmentPath = join(path, attachment.url);
+        if (looksLikeSubmission(attachment.mediaType || 'unkown/unknown', attachmentPath)) {
+          imp.attachments.push({
+            path: attachmentPath,
+            altText: attachment.name || '',
+          });
+        }
+      }
+    }
+    if (imp.attachments.length === 0) {
+      return null;
+    }
+
+    for (const tag of object.tag) {
+      if (tag?.type === 'Hashtag' && tag.name) {
+        imp.tags.push(tag.name.replace('#', ''));
+      }
+    }
+
+    return imp;
+  }
+
+  private looksLikeDirectMessage({to, cc}: ActivityPubOutboxItem): boolean {
+    for (const recipient of [...(to || []), ...(cc || [])]) {
+      // If the post goes to the public or someone's followers, it's not a DM.
+      if (/(#public|\/followers)$/i.test(recipient)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private async tryExtractImports(imports: ActivityPubImport[]): Promise<number> {
+    let successes = 0;
+    let current = 0;
+    let lastProgress = null;
+    for (const imp of imports) {
+      try {
+        await this.extractImport(imp);
+        ++successes;
+      } catch (err) {
+        this.logger.error(`${imp.id}: ${err}`, null, 'Import Error');
+        this.showImportError(`${imp.id}`);
+      }
+      ++current;
+      lastProgress = this.showImportProgress(current, imports.length, lastProgress);
+    }
+    return successes;
+  }
+
+  private async extractImport(imp: ActivityPubImport): Promise<void> {
+    const [firstAttachment, ...moreAttachments] = imp.attachments;
+    const submission = await this.createSubmission(
+      { path: firstAttachment.path },
+      this.getDefaultPartData(imp),
+    );
+    this.logger.debug(submission._id, 'Imported Submission');
+
+    for (const { path } of moreAttachments) {
+      await this.service.submissionService.addFileSubmissionAdditionalFile(
+        await this.readUploadedFile({ path }),
+        submission._id,
+        path,
+      );
+    }
+  }
+
+  private getDefaultPartData({
+    published,
+    content,
+    sensitive,
+    attachments,
+    tags,
+  }: ActivityPubImport): Promise<any> {
+    const data: any = {};
+
+    const descriptionParts = [];
+    if (content) {
+      descriptionParts.push(this.scrubHtmlDescription(content));
+    }
+    if (published) {
+      descriptionParts.push(`<p>Originally posted on ${published.substring(0, 10)}.</p>`);
+    }
+    if (descriptionParts) {
+      data.description = { overwriteDefault: false, value: descriptionParts.join('<p></p>') };
+    }
+
+    if (tags) {
+      data.tags = { extendDefault: true, value: tags };
+    }
+
+    data.rating = sensitive ? SubmissionRating.ADULT : SubmissionRating.GENERAL;
+
+    const altText = attachments[0].altText;
+    if (altText) {
+      data.altText = altText;
+    }
+
+    return data;
+  }
+
+  protected override scrubHtmlElement(elem: Element): Node | null {
+    const name = elem.name.toLowerCase();
+    const attribs = elem.attribs;
+    const classes = (attribs['class'] || '').toLowerCase().trim().split(/\s+/);
+    if (name === 'a' && classes.includes('hashtag')) {
+      // Strip hashtags from the description, they're already in the tags field.
+      return null;
+    } else {
+      return elem;
+    }
+  }
+}

--- a/electron-app/src/server/submission/submission-importer/importers/fa-archive-importer.ts
+++ b/electron-app/src/server/submission/submission-importer/importers/fa-archive-importer.ts
@@ -1,0 +1,213 @@
+import * as _ from 'lodash';
+import * as fs from 'fs-extra';
+import { DirectoryEntry, Importer } from './importer';
+import { Element, Node, Text } from 'domhandler';
+import { FileSubmissionType } from 'postybirb-commons';
+import { Logger } from '@nestjs/common';
+import { SubmissionImporterService } from '../submission-importer.service';
+import { SubmissionRating } from 'postybirb-commons';
+import { getSubmissionType } from '../../file-submission/helpers/file-submission-type.helper';
+import { parse } from 'path';
+
+interface FaArchiveImport {
+  location: 'gallery' | 'scraps';
+  id: number;
+  jsonEntry: DirectoryEntry;
+  fileEntry: DirectoryEntry;
+  thumbnailEntry?: DirectoryEntry;
+}
+
+interface FaArchiveMetadata {
+  title?: string;
+  date?: string;
+  description?: string;
+  tags?: string[];
+  rating?: string;
+}
+
+function looksLikeSubmission(name: string): boolean {
+  return getSubmissionType('unknown/unknown', name) !== FileSubmissionType.UNKNOWN;
+}
+
+function looksLikeThumbnail(name: string): boolean {
+  return /^\.(png|jpe?g)$/i.test(parse(name).ext);
+}
+
+// Imports dumps from https://github.com/askmeaboutlo0m/faescape
+export class FaArchiveImporter extends Importer {
+  private readonly logger = new Logger(FaArchiveImporter.name);
+
+  constructor(service: SubmissionImporterService) {
+    super(service);
+  }
+
+  override getName(): string {
+    return FaArchiveImporter.name;
+  }
+
+  override getDisplayName(): string {
+    return 'fa_archive dump';
+  }
+
+  override identify(tree: DirectoryEntry): boolean {
+    let hasArchiveFile = false;
+    let hasGalleryDir = false;
+    let hasScrapsDir = false;
+    for (const { type, name } of tree.entries) {
+      if (name === 'archive.chunk' && type === 'file') {
+        hasArchiveFile = true;
+      } else if (name === 'gallery' && type === 'directory') {
+        hasGalleryDir = true;
+      } else if (name === 'scraps' && type === 'directory') {
+        hasScrapsDir = true;
+      }
+    }
+    return hasArchiveFile && hasGalleryDir && hasScrapsDir;
+  }
+
+  override async extract(tree: DirectoryEntry): Promise<number> {
+    const imports: FaArchiveImport[] = [];
+    for (const { name, type, entries } of tree.entries) {
+      if ((name === 'gallery' || name === 'scraps') && type === 'directory') {
+        imports.push(...this.collectImports(name, entries));
+      }
+    }
+
+    const count = imports.length;
+    this.tryExtractImports(imports).then((successes) => {
+      this.logger.debug(`${successes}/${count} imported`, 'Imported Finished');
+      this.showCompletedNotification(successes, count);
+    });
+    return count;
+  }
+
+  private collectImports(
+    location: 'gallery' | 'scraps',
+    entries: DirectoryEntry[],
+  ): FaArchiveImport[] {
+    const imports = new Map<number, Partial<FaArchiveImport>>();
+    function importById(s: string): Partial<FaArchiveImport> {
+      const id = Number.parseInt(s, 10);
+      if (imports.has(id)) {
+        return imports.get(id);
+      } else {
+        const imp = { location, id };
+        imports.set(id, imp);
+        return imp;
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.type === 'file') {
+        const { name } = entry;
+        const match = /^(?<id>[0-9]+)(?<type>[dft])\.(?<ext>.+)$/.exec(name);
+        if (match) {
+          const { id, type, ext } = match.groups;
+          if (type === 'd' && ext === 'json') {
+            importById(id).jsonEntry = entry;
+          } else if (type === 'f' && looksLikeSubmission(name)) {
+            importById(id).fileEntry = entry;
+          } else if (type === 't' && looksLikeThumbnail(name)) {
+            importById(id).thumbnailEntry = entry;
+          }
+        }
+      }
+    }
+
+    return [...imports.values()].filter(
+      ({ jsonEntry, fileEntry }) => jsonEntry && fileEntry,
+    ) as FaArchiveImport[];
+  }
+
+  private async tryExtractImports(imports: FaArchiveImport[]): Promise<number> {
+    let successes = 0;
+    let current = 0;
+    let lastProgress = null;
+    for (const imp of _.sortBy(imports, ['id'])) {
+      try {
+        await this.extractImport(imp);
+        ++successes;
+      } catch (err) {
+        this.logger.error(`${imp.id}: ${err}`, null, 'Import Error');
+        this.showImportError(`${imp.id}`);
+      }
+      ++current;
+      lastProgress = this.showImportProgress(current, imports.length, lastProgress);
+    }
+    return successes;
+  }
+
+  private async extractImport({
+    location,
+    jsonEntry,
+    fileEntry,
+    thumbnailEntry,
+  }: FaArchiveImport): Promise<void> {
+    const submission = await this.createSubmission(
+      fileEntry,
+      await this.getDefaultPartData(jsonEntry, location === 'scraps'),
+      thumbnailEntry,
+    );
+    this.logger.debug(submission._id, 'Imported Submission');
+  }
+
+  private async getDefaultPartData({ path }: DirectoryEntry, scraps: boolean): Promise<any> {
+    const text = await fs.readFile(path, 'utf-8');
+    const metadata: FaArchiveMetadata = JSON.parse(text);
+    const { title, date, description, tags, rating } = metadata;
+    const data: any = {};
+
+    data.title = `${scraps ? 'Scrap: ' : ''}${title || parse(path).name}`;
+    data.scraps = scraps;
+
+    const descriptionParts = [];
+    if (description) {
+      descriptionParts.push(this.scrubHtmlDescription(description));
+    }
+    if (date) {
+      descriptionParts.push(`<p>Originally posted on ${date.substring(0, 10)}.</p>`);
+    }
+    if (descriptionParts) {
+      data.description = { overwriteDefault: false, value: descriptionParts.join('<p></p>') };
+    }
+
+    if (tags) {
+      data.tags = { extendDefault: true, value: tags };
+    }
+
+    if (rating === 'General') {
+      data.rating = SubmissionRating.GENERAL;
+    } else if (rating === 'Mature') {
+      data.rating = SubmissionRating.MATURE;
+    } else if (rating === 'Adult') {
+      data.rating = SubmissionRating.ADULT;
+    }
+
+    return data;
+  }
+
+  protected override scrubHtmlElement(elem: Element): Node | null {
+    const name = elem.name.toLowerCase();
+    const attribs = elem.attribs;
+    const classes = (attribs['class'] || '').toLowerCase().trim().split(/\s+/);
+    if (name === 'span' && classes.includes('parsed_nav_links')) {
+      // Submission navigation links, for comics and stuff. This just doesn't
+      // translate properly to any other website, but they usually have better
+      // navigation capability than FA in the first place.
+      return null;
+    } else if (name === 'a' && classes.includes('auto_link_shortened')) {
+      // Undo automatic link shortening, the target site can do its own thing.
+      const { href } = attribs;
+      return new Element('a', { href }, [new Text(href)]);
+    } else if (
+      name === 'a' &&
+      (classes.includes('iconusername') || classes.includes('linkusername'))
+    ) {
+      // FurAffinity username references, converted over to shortcut syntax.
+      const href = attribs.href.replace('/user/', '');
+      return new Text(`{fa:${href}}`);
+    } else {
+      return elem;
+    }
+  }
+}

--- a/electron-app/src/server/submission/submission-importer/importers/file-list-importer.ts
+++ b/electron-app/src/server/submission/submission-importer/importers/file-list-importer.ts
@@ -1,0 +1,63 @@
+import { DirectoryEntry, Importer } from './importer';
+import { FileSubmissionType, SubmissionType } from 'postybirb-commons';
+import { Logger } from '@nestjs/common';
+import { SubmissionImporterService } from '../submission-importer.service';
+import { getSubmissionType } from '../../file-submission/helpers/file-submission-type.helper';
+import * as _ from 'lodash';
+
+function looksLikeSubmissionFile(entry: DirectoryEntry): boolean {
+  return (
+    entry.type === 'file' &&
+    getSubmissionType('unknown/unknown', entry.name) !== FileSubmissionType.UNKNOWN
+  );
+}
+
+// Imports a flat file list. Doesn't descend into directories.
+export class FileListImporter extends Importer {
+  private readonly logger = new Logger(FileListImporter.name);
+
+  constructor(service: SubmissionImporterService) {
+    super(service);
+  }
+
+  override getName(): string {
+    return FileListImporter.name;
+  }
+
+  override getDisplayName(): string {
+    return 'files in directory';
+  }
+
+  override identify(tree: DirectoryEntry): boolean {
+    return tree.entries.some(looksLikeSubmissionFile);
+  }
+
+  override async extract(tree: DirectoryEntry): Promise<number> {
+    const entries = _.sortBy(tree.entries, ['name']).filter(looksLikeSubmissionFile);
+    const count = entries.length;
+    this.tryExtractFiles(entries).then((successes) => {
+      this.logger.debug(`${successes}/${count} imported`, 'Imported Finished');
+      this.showCompletedNotification(successes, count);
+    });
+    return count;
+  }
+
+  private async tryExtractFiles(entries: DirectoryEntry[]): Promise<number> {
+    let successes = 0;
+    let current = 0;
+    let lastProgress = null;
+    for (const entry of entries) {
+      try {
+        const submission = await this.createSubmission(entry);
+        this.logger.debug(submission._id, 'Imported Submission');
+        ++successes;
+      } catch (err) {
+        this.logger.error(`${entry.path}: ${err}`, null, 'Import Error');
+        this.showImportError(entry.name);
+      }
+      ++current;
+      lastProgress = this.showImportProgress(current, entries.length, lastProgress);
+    }
+    return successes;
+  }
+}

--- a/electron-app/src/server/submission/submission-importer/importers/importer.ts
+++ b/electron-app/src/server/submission/submission-importer/importers/importer.ts
@@ -1,0 +1,156 @@
+import SubmissionCreateModel from '../../models/submission-create.model';
+import SubmissionEntity from '../../models/submission.entity';
+import { NotificationType } from 'src/server/notification/enums/notification-type.enum';
+import { SubmissionCreate, SubmissionType, UploadedFile } from 'postybirb-commons';
+import { SubmissionImporterService } from '../submission-importer.service';
+import { basename } from 'path';
+import * as filetype from 'file-type';
+import * as fs from 'fs-extra';
+import * as domutils from 'domutils';
+import * as htmlparser2 from 'htmlparser2';
+import render from 'dom-serializer';
+import { Element, Node, NodeWithChildren } from 'domhandler';
+
+export interface DirectoryEntry {
+  type: 'file' | 'directory' | 'unknown';
+  name: string;
+  path: string;
+  entries: DirectoryEntry[];
+}
+
+export interface Entry {
+  name?: string;
+  path: string;
+}
+
+export abstract class Importer {
+  constructor(protected readonly service: SubmissionImporterService) {}
+
+  // Technical name for this importer.
+  abstract getName(): string;
+
+  // A humane name for this importer, shown to the user.
+  abstract getDisplayName(): string;
+
+  // Check if this looks like something this importer understands.
+  abstract identify(tree: DirectoryEntry): boolean;
+
+  // Perform the actual import, return number of submissions processed.
+  // The actual import should happen asynchronously, as to not lock up the UI.
+  abstract extract(tree: DirectoryEntry): Promise<number>;
+
+  protected async createSubmission(
+    entry: Entry,
+    defaultPartData?: any,
+    thumbnailEntry?: Entry,
+  ): Promise<SubmissionEntity> {
+    const create: SubmissionCreate = {
+      type: SubmissionType.FILE,
+      file: await this.readUploadedFile(entry),
+      path: entry.path,
+      parts: defaultPartData ? this.buildParts(defaultPartData) : null,
+    };
+    if (thumbnailEntry) {
+      create.thumbnailFile = await this.readUploadedFile(thumbnailEntry);
+      create.thumbnailPath = thumbnailEntry.path;
+    }
+    return this.service.submissionService.create(new SubmissionCreateModel(create));
+  }
+
+  private buildParts(defaultPartData: any): string {
+    return JSON.stringify([
+      {
+        accountId: 'default',
+        website: 'default',
+        isDefault: true,
+        data: defaultPartData,
+      },
+    ]);
+  }
+
+  protected async readUploadedFile({ name, path }: Entry): Promise<UploadedFile> {
+    const [buffer, mimetype] = await this.readFile(path);
+    return {
+      fieldname: null,
+      originalname: name || basename(path),
+      encoding: null,
+      mimetype,
+      buffer,
+    };
+  }
+
+  // Reads a file, returns content and mime type.
+  protected async readFile(path: string): Promise<[Buffer, string]> {
+    const buffer = await fs.readFile(path);
+    const mimetype = filetype(buffer)?.mime || 'application/octet-stream';
+    return [buffer, mimetype];
+  }
+
+  protected showCompletedNotification(successes: number, total: number): void {
+    this.service.uiNotificationService.createUINotification(
+      NotificationType.INFO,
+      10,
+      `Imported ${successes}/${total} submission(s) from ${this.getDisplayName()}.`,
+      'Import finished',
+    );
+  }
+
+  protected showImportProgress(
+    current: number,
+    total: number,
+    lastProgress: number | null,
+  ): number {
+    if (lastProgress === null) {
+      return Date.now();
+    } else if (Date.now() < lastProgress + 3000) {
+      return lastProgress;
+    } else {
+      this.service.uiNotificationService.createUIMessage(
+        NotificationType.INFO,
+        2,
+        `Importing ${current}/${total} from ${this.getDisplayName()}.`,
+      );
+      return Date.now();
+    }
+  }
+
+  protected showImportError(name: string): void {
+    this.service.uiNotificationService.createUIMessage(
+      NotificationType.ERROR,
+      10,
+      `Error importing ${name} from ${this.getDisplayName()}.`,
+    );
+  }
+
+  protected scrubHtmlDescription(description: string): string {
+    const doc = htmlparser2.parseDocument(description);
+    return render(this.scrubHtmlNode(doc));
+  }
+
+  protected scrubHtmlNode(node: Node): Node | null {
+    const scrubbed = htmlparser2.ElementType.isTag(node)
+      ? this.scrubHtmlElement(node as Element)
+      : node;
+
+    if (!scrubbed) {
+      domutils.removeElement(node);
+      return null;
+    } else if (scrubbed !== node) {
+      domutils.replaceElement(node, scrubbed);
+    }
+
+    if ('children' in scrubbed) {
+      for (const child of [...(scrubbed as NodeWithChildren).children]) {
+        this.scrubHtmlNode(child);
+      }
+    }
+
+    return scrubbed;
+  }
+
+  protected scrubHtmlElement(element: Element): Node | null {
+    // Override me. Return either the same element, a replacement node or null
+    // to remove the element from the tree altogether.
+    return element;
+  }
+}

--- a/electron-app/src/server/submission/submission-importer/submission-importer.module.ts
+++ b/electron-app/src/server/submission/submission-importer/submission-importer.module.ts
@@ -1,0 +1,11 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { SubmissionImporterService } from './submission-importer.service';
+import { SubmissionModule } from '../submission.module';
+import { NotificationModule } from '../../notification/notification.module';
+
+@Module({
+  imports: [forwardRef(() => SubmissionModule), NotificationModule],
+  providers: [SubmissionImporterService],
+  exports: [SubmissionImporterService],
+})
+export class SubmissionImporterModule {}

--- a/electron-app/src/server/submission/submission-importer/submission-importer.service.ts
+++ b/electron-app/src/server/submission/submission-importer/submission-importer.service.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs-extra';
+import { DirectoryEntry, Importer } from './importers/importer';
+import { FaArchiveImporter } from './importers/fa-archive-importer';
+import { FileListImporter } from './importers/file-list-importer';
+import { Injectable, Logger } from '@nestjs/common';
+import { SubmissionImportResult } from 'postybirb-commons';
+import { SubmissionService } from '../submission.service';
+import { UiNotificationService } from '../../notification/ui-notification/ui-notification.service';
+import { basename, join } from 'path';
+import { ActivityPubImporter } from './importers/activity-pub-importer';
+
+@Injectable()
+export class SubmissionImporterService {
+  private readonly logger = new Logger(SubmissionImporterService.name);
+  // Importers to try in this order. More specific importers must come first!
+  private readonly importers: readonly Importer[] = Object.freeze([
+    new FaArchiveImporter(this),
+    new ActivityPubImporter(this),
+    new FileListImporter(this),
+  ]);
+
+  constructor(
+    readonly submissionService: SubmissionService,
+    readonly uiNotificationService: UiNotificationService,
+  ) {}
+
+  async importDirectory(path: string): Promise<SubmissionImportResult> {
+    this.logger.debug(path, 'Import Directory');
+    const tree: DirectoryEntry = {
+      path,
+      type: 'directory',
+      name: basename(path),
+      entries: await this.readTree(path),
+    };
+
+    const importer = this.searchImporter(tree);
+    if (importer) {
+      const importType = importer.getDisplayName();
+      const submissionCount = await importer.extract(tree);
+      return { importType, submissionCount };
+    } else {
+      return { importType: null, submissionCount: 0 };
+    }
+  }
+
+  private async readTree(parent: string): Promise<DirectoryEntry[]> {
+    const files = await fs.readdir(parent);
+    return await Promise.all(
+      files.map(async (name): Promise<DirectoryEntry> => {
+        const path = join(parent, name);
+        const stat = await fs.lstat(path);
+        if (stat.isFile()) {
+          return { type: 'file', entries: [], name, path };
+        } else if (stat.isDirectory()) {
+          return { type: 'directory', entries: await this.readTree(path), name, path };
+        } else {
+          return { type: 'unknown', entries: [], name, path };
+        }
+      }),
+    );
+  }
+
+  private searchImporter(tree: DirectoryEntry): Importer | null {
+    for (const importer of this.importers) {
+      const name = importer.getName();
+      try {
+        if (importer.identify(tree)) {
+          this.logger.debug('Identified', name);
+          return importer;
+        } else {
+          this.logger.debug('Not identified', name);
+        }
+      } catch (err) {
+        this.logger.error(`${err}`, name);
+      }
+    }
+    return null;
+  }
+}

--- a/electron-app/src/server/submission/submission.controller.ts
+++ b/electron-app/src/server/submission/submission.controller.ts
@@ -11,6 +11,7 @@ import {
   Patch,
 } from '@nestjs/common';
 import { SubmissionService } from './submission.service';
+import { SubmissionImporterService } from './submission-importer/submission-importer.service';
 import { SubmissionType } from 'postybirb-commons';
 import {
   SubmissionUpdate,
@@ -24,6 +25,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import SubmissionScheduleModel from './models/submission-schedule.model';
 import SubmissionLogEntity from './log/models/submission-log.entity';
 import SubmissionCreateModel from './models/submission-create.model';
+import SubmissionImportModel from './models/submission-import.model';
 
 interface FileChangeBodyDTO {
   path: string;
@@ -35,7 +37,10 @@ interface FileChangeParamsDTO {
 
 @Controller('submission')
 export class SubmissionController {
-  constructor(private readonly service: SubmissionService) {}
+  constructor(
+    private readonly service: SubmissionService,
+    private readonly importerService: SubmissionImporterService,
+  ) {}
 
   private isTrue(value: string): boolean {
     return value === 'true' || value === '';
@@ -71,6 +76,11 @@ export class SubmissionController {
   @Post('recreate')
   async recreateFromLog(@Body() log: SubmissionLogEntity) {
     return this.service.recreate(log);
+  }
+
+  @Post('import')
+  async importDirectory(@Body() { path }: SubmissionImportModel) {
+    return this.importerService.importDirectory(path);
   }
 
   @Patch('update')

--- a/electron-app/src/server/submission/submission.module.ts
+++ b/electron-app/src/server/submission/submission.module.ts
@@ -17,6 +17,7 @@ import { DatabaseFactory } from 'src/server/database/database.factory';
 import { ParserModule } from './parser/parser.module';
 import SubmissionEntity from './models/submission.entity';
 import FileSubmissionEntity from './file-submission/models/file-submission.entity';
+import { SubmissionImporterModule } from './submission-importer/submission-importer.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import FileSubmissionEntity from './file-submission/models/file-submission.entit
     SubmissionPartModule,
     SubmissionTemplateModule,
     ParserModule,
+    SubmissionImporterModule,
   ],
   controllers: [SubmissionController],
   providers: [

--- a/electron-app/src/server/submission/submission.service.ts
+++ b/electron-app/src/server/submission/submission.service.ts
@@ -552,7 +552,7 @@ export class SubmissionService {
 
     const allParts = await this.partService.getPartsForSubmission(submission._id, false);
     const keepIds = submissionOverwrite.parts.map((p) => p.accountId);
-    const removeParts = allParts.filter((p) => !keepIds.includes(p.accountId));
+    const removeParts = allParts.filter((p) => !keepIds.includes(p.accountId) && !p.isDefault);
 
     await Promise.all(submissionOverwrite.parts.map((part) => this.setPart(submission, part)));
     await Promise.all(removeParts.map((p) => this.partService.removeSubmissionPart(p._id)));

--- a/electron-app/src/server/submission/submission.service.ts
+++ b/electron-app/src/server/submission/submission.service.ts
@@ -179,6 +179,20 @@ export class SubmissionService {
       throw new InternalServerErrorException(err.message);
     }
 
+    const { thumbnailFile, thumbnailPath } = createDto;
+    if (completedSubmission.primary && thumbnailFile && thumbnailPath) {
+      try {
+        await this.fileSubmissionService.changeThumbnailFile(
+          completedSubmission,
+          thumbnailFile,
+          thumbnailPath,
+        );
+      } catch (err) {
+        // Failure to set a thumbnail is not fatal, just keep going
+        this.logger.error(err.message, err.stack, 'Create Thumbnail Failure');
+      }
+    }
+
     try {
       const submission = await this.repository.save(completedSubmission);
       await this.partService.createDefaultPart(completedSubmission);

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -7,11 +7,24 @@ import './styles/submission.css';
 import { Authorizer } from './websites/interfaces/authorizer.interface';
 
 declare global {
+  interface ElectronOpenDialogOptions {
+    title?: string;
+    properties?: Array<'openFile' | 'openDirectory'>;
+  }
+
+  interface ElectronOpenDialogReturnValue {
+    canceled: boolean;
+    filePaths: string[];
+  }
+
   interface Window {
     electron: {
       clipboard: {
         availableFormats: () => string[];
         read: () => File;
+      };
+      dialog: {
+        showOpenDialog(options?: ElectronOpenDialogOptions): Promise<ElectronOpenDialogReturnValue>;
       };
       session: {
         getCookies(accountId: string): Promise<any[]>;

--- a/ui/src/services/submission.service.ts
+++ b/ui/src/services/submission.service.ts
@@ -1,5 +1,6 @@
 import { FileRecord } from 'postybirb-commons';
 import { SubmissionCreate } from 'postybirb-commons';
+import { SubmissionImportResult } from 'postybirb-commons';
 import { SubmissionOverwrite } from 'postybirb-commons';
 import { SubmissionPackage } from 'postybirb-commons';
 import { SubmissionUpdate } from 'postybirb-commons';
@@ -28,6 +29,12 @@ export default class SubmissionService {
     formData.set('file', window.electron.clipboard.read());
     formData.set('type', 'FILE');
     return axios.post('/submission/create/', formData);
+  }
+
+  static importFromDirectory(path: string) {
+    return axios
+      .post<SubmissionImportResult>('/submission/import', { path })
+      .then(({ data }) => data);
   }
 
   static changeFallback(id: string, file: File) {

--- a/ui/src/views/submissions/editable-submissions/FileSubmissionCreator.tsx
+++ b/ui/src/views/submissions/editable-submissions/FileSubmissionCreator.tsx
@@ -52,6 +52,29 @@ export class FileSubmissionCreator extends React.Component<any, FileSubmissionCr
       .catch(() => message.error('Failed to create submission.'));
   }
 
+  createFromImport() {
+    window.electron.dialog
+      .showOpenDialog({ title: 'Choose directory to import', properties: ['openDirectory'] })
+      .then(({ canceled, filePaths }) => {
+        if (!canceled && filePaths && filePaths.length > 0) {
+          return SubmissionService.importFromDirectory(filePaths[0]);
+        } else {
+          return null;
+        }
+      })
+      .then(result => {
+        if (result) {
+          const { importType, submissionCount } = result;
+          if (importType && submissionCount !== 0) {
+            message.success(`Importing ${submissionCount} submission(s) from ${importType}.`);
+          } else {
+            message.error('Found nothing to import.');
+          }
+        }
+      })
+      .catch(() => message.error('Failed to import submissions.'));
+  }
+
   performUpload = _.debounce(async (files: RcFile[]) => {
     const isPoster: boolean = this.uploadQueue.length === 0;
     if (files) {
@@ -123,6 +146,12 @@ export class FileSubmissionCreator extends React.Component<any, FileSubmissionCr
           >
             <Icon type="copy" />
             Copy from clipboard
+          </Button>
+        </div>
+        <div className="mt-1">
+          <Button onClick={this.createFromImport.bind(this)} block>
+            <Icon type="folder" />
+            Import directory
           </Button>
         </div>
         <div className="mt-1 flex">

--- a/ui/src/views/submissions/submission-forms/form-components/ImportDataSelect.tsx
+++ b/ui/src/views/submissions/submission-forms/form-components/ImportDataSelect.tsx
@@ -102,21 +102,19 @@ export default class ImportDataSelect extends React.Component<Props, State> {
     return [];
   };
 
-  shouldSelectPart = (part: SubmissionPart<any>): boolean => {
-    // Don't pre-select the default section when it's empty. The user probably
-    // doesn't want their defaults clobbered with nothingness.
+  static isEmptyDefaultPart(part: SubmissionPart<any>): boolean {
     if (part.isDefault) {
       const defaultOptions: DefaultOptions = part.data;
-      return !!(
+      return !(
         defaultOptions.title?.trim() ||
         defaultOptions.tags?.value?.length ||
         defaultOptions.description?.value?.trim() ||
         !_.isNil(defaultOptions.rating)
       );
     } else {
-      return true;
+      return false;
     }
-  };
+  }
 
   render() {
     const title = this.props.label || 'Import';
@@ -146,7 +144,9 @@ export default class ImportDataSelect extends React.Component<Props, State> {
                   selected: parts,
                   selectedFields: parts
                     ? Object.values(parts)
-                        .filter(this.shouldSelectPart)
+                        // Don't pre-select the default section when it's empty. The user
+                        // probably doesn't want their defaults clobbered with nothingness.
+                        .filter(_.negate(ImportDataSelect.isEmptyDefaultPart))
                         .map(p => p.accountId)
                     : []
                 });

--- a/ui/src/views/submissions/submission-forms/form-components/ImportDataSelect.tsx
+++ b/ui/src/views/submissions/submission-forms/form-components/ImportDataSelect.tsx
@@ -8,6 +8,7 @@ import { TreeNode } from 'antd/lib/tree-select';
 import { WebsiteRegistry } from '../../../../websites/website-registry';
 import SubmissionTemplateSelect from '../../submission-template-select/SubmissionTemplateSelect';
 import { SubmissionType } from 'postybirb-commons';
+import { DefaultOptions } from 'postybirb-commons';
 
 interface Props {
   className?: string;
@@ -101,6 +102,22 @@ export default class ImportDataSelect extends React.Component<Props, State> {
     return [];
   };
 
+  shouldSelectPart = (part: SubmissionPart<any>): boolean => {
+    // Don't pre-select the default section when it's empty. The user probably
+    // doesn't want their defaults clobbered with nothingness.
+    if (part.isDefault) {
+      const defaultOptions: DefaultOptions = part.data;
+      return !!(
+        defaultOptions.title?.trim() ||
+        defaultOptions.tags?.value?.length ||
+        defaultOptions.description?.value?.trim() ||
+        !_.isNil(defaultOptions.rating)
+      );
+    } else {
+      return true;
+    }
+  };
+
   render() {
     const title = this.props.label || 'Import';
     return (
@@ -127,7 +144,11 @@ export default class ImportDataSelect extends React.Component<Props, State> {
               onSelect={(id, type, parts) => {
                 this.setState({
                   selected: parts,
-                  selectedFields: parts ? Object.values(parts).map(p => p.accountId) : []
+                  selectedFields: parts
+                    ? Object.values(parts)
+                        .filter(this.shouldSelectPart)
+                        .map(p => p.accountId)
+                    : []
                 });
               }}
             />

--- a/ui/src/views/submissions/submission-forms/forms/MultiSubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/MultiSubmissionEditForm.tsx
@@ -125,6 +125,17 @@ class MultiSubmissionEditForm extends React.Component<Props, MultiSubmissionEdit
   };
 
   importData(parts: Array<SubmissionPart<any>>) {
+    // Set the keep default option to a reasonable state. If there's anything
+    // written into the defaults in this form or if there's explicitly a default
+    // given by the template, we want to use that default part. Otherwise we
+    // want to keep it, since clobbering stuff with blank defaults is useless.
+    // If the user has unusual desires, they can (un)check it again themselves.
+    const existingDefaultPart = Object.values(this.state.parts).find(part => part.isDefault);
+    const haveExistingDefault =
+      existingDefaultPart && !ImportDataSelect.isEmptyDefaultPart(existingDefaultPart);
+    const haveDefaultInTemplate = !!parts.find(part => part.isDefault);
+    this.setState({ keepDefault: !haveExistingDefault && !haveDefaultInTemplate });
+
     parts.forEach(p => {
       const existing = Object.values(this.state.parts).find(part => part.accountId === p.accountId);
       p.submissionId = 'multi';

--- a/ui/src/views/submissions/submission-forms/forms/MultiSubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/MultiSubmissionEditForm.tsx
@@ -27,7 +27,8 @@ import {
   TreeSelect,
   Anchor,
   Popconfirm,
-  Alert
+  Alert,
+  Checkbox
 } from 'antd';
 
 interface Props {
@@ -42,6 +43,7 @@ export interface MultiSubmissionEditFormState {
   touched: boolean;
   removedParts: string[];
   saveVisible: boolean;
+  keepDefault: boolean;
 }
 
 @inject('loginStatusStore')
@@ -79,7 +81,8 @@ class MultiSubmissionEditForm extends React.Component<Props, MultiSubmissionEdit
     loading: false,
     touched: false,
     removedParts: [],
-    saveVisible: false
+    saveVisible: false,
+    keepDefault: false
   };
 
   constructor(props: Props) {
@@ -100,6 +103,9 @@ class MultiSubmissionEditForm extends React.Component<Props, MultiSubmissionEdit
     this.setState({ loading: true, saveVisible: false });
     const updatedParts = _.cloneDeep(this.state.parts);
     this.state.removedParts.forEach(accountId => delete updatedParts[accountId]);
+    if (this.state.keepDefault) {
+      delete updatedParts.default;
+    }
     Promise.all(
       selected.map(submission =>
         SubmissionService.overwriteSubmissionParts({
@@ -333,11 +339,21 @@ class MultiSubmissionEditForm extends React.Component<Props, MultiSubmissionEdit
                     Defaults
                   </span>
                 </Typography.Title>
-                <DefaultFormSection
-                  part={this.state.parts.default}
-                  onUpdate={this.onUpdate}
-                  submission={{} as any}
-                />
+                <div className="ant-form-item">
+                  <Checkbox
+                    checked={this.state.keepDefault}
+                    onChange={e => this.setState({ keepDefault: e.target.checked })}
+                  >
+                    Keep defaults
+                  </Checkbox>
+                </div>
+                {!this.state.keepDefault && (
+                  <DefaultFormSection
+                    part={this.state.parts.default}
+                    onUpdate={this.onUpdate}
+                    submission={{} as any}
+                  />
+                )}
               </Form.Item>
 
               <Form.Item className="form-section jumpable-section">


### PR DESCRIPTION
Allows the user to press on a new "import directory" button on the file submissions page and choose a directory to import from. The directory will be inspected and an appropriate importer chosen automatically. The
submissions will then be imported in logical order, potentially including thumbnails, titles, descriptions etc.

Currently the following importers are implemented, because they are the ones I need:

* A flat file importer. Just gobbles up all the files in a directory.

* An importer for ActivityPub exports, like they fall out of Mastodon for example. Grabs all media posts that aren't direct messages and turns them into submissions with descriptions and tags.

* An importer for [this FurAffinity archiver](https://github.com/askmeaboutlo0m/faescape), which will import submissions with titles, descriptions, tags, ratings and thumbnails.

Further importers can be added pretty easily by extending `Importer` and adding an entry in the `SubmissionImporterService.importers` array. The importers `inspect` the directory and decide if they're equipped to handle them. The first matching importer will be chosen to do the extraction.

The progress reporting is kinda ugly with periodic messages in the corner, but it does the job.

Also adds thumbnails on submission creation in the backend, so that the importers can make use of that.

Another ancillary change is a checkbox on the edit many submissions form that allows keeping of the default section. That makes it actually useful for imported submissions, since they'll have their default section set, but still need to be equipped with other sections in large numbers. The commit messages have further details.

Implements #170.

This is kind of pertinent currently, due to some mess with FurAffinity that puts a lot of artists in the firing line of a permaban, so many are looking to diversify. They got until July 1st to do it, basically. If you don't have time to handle this PR currently, let me know, then I'll look into providing some other emergency measures in the meantime.

I'm also available in the PostyBirb Discord as "askmeaboutloom", if that's more convenient for communication.