### PR TITLE
Scroll back to edited submission

### DIFF
--- a/ui/src/stores/scroll-submission.store.ts
+++ b/ui/src/stores/scroll-submission.store.ts
@@ -1,0 +1,18 @@
+const STORE_KEY: string = 'ScrollSubmissionId';
+
+class ScrollSubmissionStore {
+  set(submissionId: string) {
+    sessionStorage.setItem(STORE_KEY, submissionId);
+  }
+
+  check(submissionId: string) {
+    if (sessionStorage.getItem(STORE_KEY) === submissionId) {
+      sessionStorage.removeItem(STORE_KEY);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+export const scrollSubmissionStore = new ScrollSubmissionStore();

--- a/ui/src/views/submissions/editable-submissions/EditableSubmissionListItem.tsx
+++ b/ui/src/views/submissions/editable-submissions/EditableSubmissionListItem.tsx
@@ -23,6 +23,7 @@ import { SubmissionType } from 'postybirb-commons';
 import SubmissionUtil from '../../../utils/submission.util';
 import { WebsiteRegistry } from '../../../websites/website-registry';
 import { IssueState } from './IssueState';
+import { scrollSubmissionStore } from '../../../stores/scroll-submission.store';
 
 interface ListItemProps {
   item: SubmissionPackage<Submission>;
@@ -167,6 +168,13 @@ export class EditableSubmissionListItem extends React.Component<ListItemProps, L
     }
     return null;
   }
+
+  scrollTo = (elem: HTMLElement | null): void => {
+    if (scrollSubmissionStore.check(this.props.item.submission._id) && elem) {
+      elem.scrollIntoView();
+    }
+  };
+
   render() {
     const { item } = this.props;
     const problems: Problems = item.problems;
@@ -247,7 +255,7 @@ export class EditableSubmissionListItem extends React.Component<ListItemProps, L
             >
               <List.Item.Meta
                 avatar={
-                  <div>
+                  <div ref={this.scrollTo}>
                     {item.submission.type === SubmissionType.FILE ? (
                       <div className="cursor-zoom-in" onClick={this.showPreview.bind(this)}>
                         <Avatar

--- a/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
@@ -139,7 +139,11 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
     ).then(({ data }) => this.setState({ problems: data }));
   }, 1250);
 
-  onSubmit = () => {
+  close(): void {
+    this.props.history.push(`/${this.state.submissionType}`);
+  }
+
+  onSubmit(close: boolean) {
     return new Promise(resolve => {
       if (this.state.touched || this.scheduleHasChanged()) {
         const submissionFromStore = submissionStore.getSubmission(this.id);
@@ -169,6 +173,9 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
               touched: false
             });
             message.success('Submission was successfully saved.');
+            if (close) {
+              this.close();
+            }
           })
           .catch(() => {
             this.setState({ loading: false });
@@ -177,11 +184,19 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
           .finally(resolve);
       }
     });
+  }
+
+  onClose = () => {
+    if (this.formHasChanges()) {
+      this.onSubmit(true);
+    } else {
+      this.close();
+    }
   };
 
   onPost = async (saveFirst: boolean) => {
     if (saveFirst) {
-      await this.onSubmit();
+      await this.onSubmit(false);
     }
 
     uiStore.setPendingChanges(false);
@@ -877,11 +892,19 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
 
             <Button
               className="mr-1"
-              onClick={this.onSubmit}
+              onClick={() => this.onSubmit(false)}
               type="primary"
               disabled={!this.formHasChanges()}
             >
               Save
+            </Button>
+
+            <Button
+              className="mr-1"
+              onClick={this.onClose}
+              type={this.formHasChanges() ? 'primary' : 'default'}
+            >
+              {this.formHasChanges() ? 'Save and Close' : 'Close'}
             </Button>
 
             {isPosting ? (

--- a/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
@@ -45,6 +45,7 @@ import {
   Tooltip
 } from 'antd';
 import { Problem } from 'postybirb-commons';
+import { scrollSubmissionStore } from '../../../../stores/scroll-submission.store';
 
 interface Props {
   match: Match;
@@ -116,6 +117,10 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
       .catch(() => {
         props.history.push('/home');
       });
+  }
+
+  componentDidMount() {
+    scrollSubmissionStore.set(this.id);
   }
 
   onUpdate = (updatePart: SubmissionPart<any> | Array<SubmissionPart<any>>) => {


### PR DESCRIPTION
After editing it, since when you have a lot of submissions to edit it's really annoying to have to scroll down and find your spot again.

Not sure if this is a legitimate way to handle this, but hacking this in improved usability for me a whole bunch.