### PR TITLE
Fix Telegram not logging in with 2FA enabled

### DIFF
--- a/electron-app/src/server/websites/telegram/telegram.service.ts
+++ b/electron-app/src/server/websites/telegram/telegram.service.ts
@@ -119,7 +119,7 @@ export class Telegram extends Website {
           srp_B: string;
         }>(data.appId, 'account.getPassword', {});
 
-        const { A, M1 } = (await this.instances[data.appId] as any).crypto.getSRPParams({
+        const { A, M1 } = await (this.instances[data.appId] as any).crypto.getSRPParams({
           g,
           p,
           salt1,


### PR DESCRIPTION
Just a misplaced parenthesis causing it.