### PR TITLE
fix: Better handling of insufficient tags for Artconomy.

### DIFF
--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -229,12 +229,28 @@ export class Artconomy extends Website {
     const files = [
       submission.primary,
       ...(submission.additional || []).filter(
-        f => !f.ignoredAccounts!.includes(submissionPart.accountId),
+        (f) => !f.ignoredAccounts!.includes(submissionPart.accountId),
       ),
     ];
 
-    const maxMB: number = 99;
-    files.forEach(file => {
+    const tags = [...submissionPart.data.tags.value];
+    if (submissionPart.data.tags.extendDefault) {
+      tags.push(...defaultPart.data.tags.value);
+    }
+
+    if (tags.length < 5) {
+      problems.push(
+        'You must have at least 5 tags. Think about the following: ' +
+          'sex/gender (required, if character), ' +
+          'species (ditto), kinks/fetishes (ditto), genre, subject matter, ' +
+          'focus of the piece, location, pose/position, art style, ' +
+          'clothing/accessories, ' +
+          'relationships depicted',
+      );
+    }
+
+    const maxMB = 99;
+    files.forEach((file) => {
       const { type, size, name, mimetype } = file;
       if (!WebsiteValidator.supportsFileType(file, this.acceptsFiles)) {
         problems.push(`Does not support file format: (${name}) ${mimetype}.`);


### PR DESCRIPTION
This PR adds a problem message if there are not enough tags to post to Artconomy, rather than failing upon attempt to post.

**Testing instructions**:

1. Create a post
2. Add Artconomy as a target
3. Use insufficient tags, with or without the 'extend default' option. Verify problem message is displayed.
4. Use sufficient tags and verify the problem message is removed.

Screenshot of problem message:

![image](https://github.com/mvdicarlo/postybirb-plus/assets/1099483/bbdb755d-3a63-445f-9274-e59bdb2345ff)
