### PR TITLE
Allow posting to Discord forum channels

### DIFF
--- a/electron-app/src/server/websites/discord/discord.account.interface.ts
+++ b/electron-app/src/server/websites/discord/discord.account.interface.ts
@@ -1,4 +1,5 @@
 export interface DiscordAccountData {
   name: string;
   webhook: string;
+  forum: boolean;
 }

--- a/ui/src/websites/discord/DiscordLogin.tsx
+++ b/ui/src/websites/discord/DiscordLogin.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { LoginDialogProps } from '../interfaces/website.interface';
-import { Form, Input, Button, message } from 'antd';
+import { Form, Input, Button, Checkbox, message } from 'antd';
 import LoginService from '../../services/login.service';
 import BrowserLink from '../../components/BrowserLink';
 
 interface State {
   name: string;
   webhook: string;
+  forum: boolean,
   sending: boolean;
 }
 
@@ -14,6 +15,7 @@ export default class DiscordLogin extends React.Component<LoginDialogProps, Stat
   state: State = {
     name: '',
     webhook: '',
+    forum: false,
     sending: false
   };
 
@@ -29,7 +31,8 @@ export default class DiscordLogin extends React.Component<LoginDialogProps, Stat
     this.setState({ sending: true });
     LoginService.setAccountData(this.props.account._id, {
       name: this.state.name,
-      webhook: this.state.webhook
+      webhook: this.state.webhook,
+      forum: this.state.forum,
     })
       .then(() => {
         message.success('Discord updated.');
@@ -67,6 +70,14 @@ export default class DiscordLogin extends React.Component<LoginDialogProps, Stat
               defaultValue={this.state.webhook}
               onBlur={({ target }) => this.setState({ webhook: target.value })}
             />
+          </Form.Item>
+          <Form.Item>
+            <Checkbox
+              checked={this.state.forum}
+              onChange={e => this.setState({ forum: e.target.checked })}
+            >
+              Webhook points at a forum channel, not a regular text channel
+            </Checkbox>
           </Form.Item>
           <Form.Item>
             <Button


### PR DESCRIPTION
Discord forum channels require a `thread_name` to be passed as a query parameter of the first post, with subsequent posts in the same thread using a `thread_id` parameter in the body. Annoyingly, they validate it both ways, so we can't just always send those parameters, the user has to tick a box in the account settings if the target is a forum channel instead of a regular message channel.

This also changes file posting to stick everything into a single post instead of splitting it up into a notification message and one message per file. Presumably Discord didn't use to support that, but it does now, using the `files[n]` instead of `file` to attach files and a `payload_json` parameter to attach nested data into a multipart form.