### PR TITLE
itaku post to feed & visibility options

### DIFF
--- a/electron-app/src/server/websites/itaku/itaku.service.ts
+++ b/electron-app/src/server/websites/itaku/itaku.service.ts
@@ -137,8 +137,11 @@ export class Itaku extends Website {
       tags: JSON.stringify(data.tags.map((tag) => ({ name: tag }))),
       visibility: data.options.visibility,
       image: data.primary.file,
-      add_to_feed: `${data.options.shareOnFeed}`,
     };
+    
+    if (data.options.shareOnFeed) {
+      postData.add_to_feed = true;
+    }
 
     if (data.options.spoilerText) {
       postData.content_warning = data.options.spoilerText;

--- a/ui/src/websites/itaku/Itaku.tsx
+++ b/ui/src/websites/itaku/Itaku.tsx
@@ -126,6 +126,17 @@ export class ItakuNotificationSubmissionForm extends GenericSubmissionSection<
             <Select.Option value={f.value}>{f.label}</Select.Option>
           ))}
         </Select>
+      </Form.Item>,
+      <Form.Item label="Visibility">
+        <Select
+          {...GenericSelectProps}
+          className="w-full"
+          value={data.visibility}
+          onChange={this.setValue.bind(this, 'visibility')}
+        >
+          <Select.Option value={'PUBLIC'}>Public Post</Select.Option>
+          <Select.Option value={'PROFILE_ONLY'}>Profile Only</Select.Option>
+        </Select>
       </Form.Item>
     );
     return elements;
@@ -174,6 +185,18 @@ export class ItakuFileSubmissionForm extends GenericFileSubmissionSection<ItakuF
           {this.state.folders.map(f => (
             <Select.Option value={f.value}>{f.label}</Select.Option>
           ))}
+        </Select>
+      </Form.Item>,
+      <Form.Item label="Visibility">
+        <Select
+          {...GenericSelectProps}
+          className="w-full"
+          value={data.visibility}
+          onChange={this.setValue.bind(this, 'visibility')}
+        >
+          <Select.Option value={'PUBLIC'}>Public Gallery</Select.Option>
+          <Select.Option value={'PROFILE_ONLY'}>Profile Only</Select.Option>
+          <Select.Option value={'UNLISTED'}>Unlisted</Select.Option>
         </Select>
       </Form.Item>
     );


### PR DESCRIPTION
Apparently itaku wants the field absent if you don't want to post to the feed. Even supplying `add_to_feed: false` enables it.