### PR TITLE
Disable Jimp JPEG decoder memory limit

### DIFF
--- a/electron-app/src/server/file-manipulation/manipulators/image.manipulator.worker.ts
+++ b/electron-app/src/server/file-manipulation/manipulators/image.manipulator.worker.ts
@@ -6,6 +6,16 @@ setTimeout(() => {
   process.exit(1);
 }, 60000 * 30);
 
+// Work around Jimp's hard-coded memory limit when loading JPEG files.
+// See https://github.com/jimp-dev/jimp/issues/915
+(function () {
+  const decoder: any = Jimp.decoders['image/jpeg']
+  Jimp.decoders['image/jpeg'] = (data: any) => {
+    const userOpts = { maxMemoryUsageInMB: Number.POSITIVE_INFINITY };
+    return decoder(data, userOpts);
+  }
+}());
+
 let manipulator = null; // JIMP
 process.on('message', async (msg: any) => {
   let hasChanges = false;


### PR DESCRIPTION
It's capped at some fixed value, which botches loading images of larger resolutions for no good reasons This disables the limit in the deferred image manipualtion worker. Presumably the same manipulation isn't necessary in the non-deferred variant, since those images are tiny.

Upstream issue: https://github.com/jimp-dev/jimp/issues/915