### PR TITLE
Increase discord size limit to 25Mb

### DIFF
--- a/electron-app/src/server/websites/discord/discord.service.ts
+++ b/electron-app/src/server/websites/discord/discord.service.ts
@@ -139,11 +139,11 @@ export class Discord extends Website {
       ),
     ];
 
-    const maxMB: number = 8;
+    const maxMB: number = 25;
     files.forEach(file => {
       const { type, size, name, mimetype } = file;
       if (FileSize.MBtoBytes(maxMB) < size) {
-        warnings.push(`Discord requires files be 8MB or less, unless your channel has been boosted.`);
+        warnings.push(`Discord requires files be 25MB or less, unless your channel has been boosted.`);
       }
     });
 


### PR DESCRIPTION
Discord have increased the basic file size limit for all users as mentioned on the discord server; verified online.