### PR TITLE
Fix imports in submission importer

### DIFF
--- a/electron-app/src/server/submission/submission-importer/importers/importer.ts
+++ b/electron-app/src/server/submission/submission-importer/importers/importer.ts
@@ -6,8 +6,8 @@ import { SubmissionImporterService } from '../submission-importer.service';
 import { basename } from 'path';
 import filetype from 'file-type';
 import fs from 'fs-extra';
-import domutils from 'domutils';
-import htmlparser2 from 'htmlparser2';
+import * as domutils from 'domutils';
+import * as htmlparser2 from 'htmlparser2';
 import render from 'dom-serializer';
 import { Element, Node, NodeWithChildren } from 'domhandler';
 


### PR DESCRIPTION
For some reason default importing these worked before, but have now started importing `undefined` instead, causing the importer to stop working. Switching the imports over to not be default imports makes them work again.