### PR TITLE
weasyl: Avoid requesting folders for undefined user

### DIFF
--- a/electron-app/src/server/websites/weasyl/weasyl.service.ts
+++ b/electron-app/src/server/websites/weasyl/weasyl.service.ts
@@ -49,7 +49,9 @@ export class Weasyl extends Website {
     const login: string = _.get(res.body, 'login');
     status.loggedIn = !!login;
     status.username = login;
-    await this.retrieveFolders(data._id, status.username);
+    if (status.loggedIn) {
+      await this.retrieveFolders(data._id, status.username);
+    }
     return status;
   }
 


### PR DESCRIPTION
“undefined” is someone’s username. (Weasyl gets about 2k requests for this every day.)

Note: I’m not able to test this; not sure if it needs a fallback `this.accountInformation.set(data._id, { folders: [] });`.