### PR TITLE
Replies for Mastodon and Bluesky

### DIFF
--- a/commons/src/interfaces/websites/bluesky/bluesky.file.options.interface.ts
+++ b/commons/src/interfaces/websites/bluesky/bluesky.file.options.interface.ts
@@ -3,4 +3,5 @@ import { DefaultFileOptions } from '../../submission/default-options.interface';
 export interface BlueskyFileOptions extends DefaultFileOptions {
   altText?: string;
   label_rating: string;
+  replyToUrl?: string;
 }

--- a/commons/src/interfaces/websites/bluesky/bluesky.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/bluesky/bluesky.notification.options.interface.ts
@@ -2,4 +2,5 @@ import { DefaultOptions } from '../../submission/default-options.interface';
 
 export interface BlueskyNotificationOptions extends DefaultOptions {
   label_rating: string;
+  replyToUrl?: string;
 }

--- a/commons/src/interfaces/websites/mastodon/mastodon.file.options.interface.ts
+++ b/commons/src/interfaces/websites/mastodon/mastodon.file.options.interface.ts
@@ -5,4 +5,5 @@ export interface MastodonFileOptions extends DefaultFileOptions {
   spoilerText?: string;
   visibility: string;
   altText?: string;
+  replyToUrl?: string;
 }

--- a/commons/src/interfaces/websites/mastodon/mastodon.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/mastodon/mastodon.notification.options.interface.ts
@@ -4,4 +4,5 @@ export interface MastodonNotificationOptions extends DefaultOptions {
   useTitle: boolean;
   spoilerText?: string;
   visibility: string;
+  replyToUrl?: string;
 }

--- a/commons/src/websites/bluesky/bluesky.file.options.ts
+++ b/commons/src/websites/bluesky/bluesky.file.options.ts
@@ -19,6 +19,11 @@ export class BlueskyFileOptionsEntity
   @DefaultValue('')
   label_rating: string = '';
 
+  @Expose()
+  @IsOptional()
+  @IsString()
+  replyToUrl?: string;
+
   constructor(entity?: Partial<BlueskyFileOptions>) {
     super(entity as DefaultFileOptions);
   }

--- a/commons/src/websites/bluesky/bluesky.notification.options.ts
+++ b/commons/src/websites/bluesky/bluesky.notification.options.ts
@@ -14,6 +14,11 @@ export class BlueskyNotificationOptionsEntity
   @DefaultValue('')
   label_rating: string = '';
 
+  @Expose()
+  @IsOptional()
+  @IsString()
+  replyToUrl?: string;
+
   constructor(entity?: Partial<BlueskyNotificationOptions>) {
     super(entity as DefaultOptions);
   }

--- a/commons/src/websites/mastodon/mastodon.file.options.ts
+++ b/commons/src/websites/mastodon/mastodon.file.options.ts
@@ -29,6 +29,11 @@ export class MastodonFileOptionsEntity
   @IsString()
   altText?: string;
 
+  @Expose()
+  @IsOptional()
+  @IsString()
+  replyToUrl?: string;
+
   constructor(entity?: Partial<MastodonFileOptions>) {
     super(entity as DefaultFileOptions);
   }

--- a/commons/src/websites/mastodon/mastodon.notification.options.ts
+++ b/commons/src/websites/mastodon/mastodon.notification.options.ts
@@ -24,6 +24,11 @@ export class MastodonNotificationOptionsEntity
   @DefaultValue('public')
   visibility!: string;
 
+  @Expose()
+  @IsOptional()
+  @IsString()
+  replyToUrl?: string;
+
   constructor(entity?: Partial<MastodonNotificationOptions>) {
     super(entity as DefaultOptions);
   }

--- a/ui/src/websites/bluesky/Bluesky.tsx
+++ b/ui/src/websites/bluesky/Bluesky.tsx
@@ -62,7 +62,10 @@ BlueskyNotificationOptions
           <Select.Option value={'nudity'}>Adult: Nudity</Select.Option>
           <Select.Option value={'porn'}>Adult: Porn</Select.Option>
         </Select>
-      </Form.Item>,            
+      </Form.Item>,
+      <Form.Item label="Reply To Post URL">
+        <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+      </Form.Item>,
     );
     return elements;
   }
@@ -84,12 +87,15 @@ export class BlueskyFileSubmissionForm extends GenericFileSubmissionSection<Blue
           <Select.Option value={'nudity'}>Adult: Nudity</Select.Option>
           <Select.Option value={'porn'}>Adult: Porn</Select.Option>
         </Select>
-      </Form.Item>,      
+      </Form.Item>,
       <Form.Item label="Alt Text">
         <Input
           value={data.altText}
           onChange={this.handleValueChange.bind(this, 'altText')}
         />
+      </Form.Item>,
+      <Form.Item label="Reply To Post URL">
+        <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
       </Form.Item>,
     );
     return elements;

--- a/ui/src/websites/mastodon/Mastodon.tsx
+++ b/ui/src/websites/mastodon/Mastodon.tsx
@@ -90,7 +90,10 @@ class MastodonNotificationSubmissionForm extends GenericSubmissionSection<
           <Select.Option value="private">Followers Only</Select.Option>
           <Select.Option value="direct">Mentioned Users Only</Select.Option>
         </Select>
-      </Form.Item>
+      </Form.Item>,
+      <Form.Item label="Reply To Post URL">
+        <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+      </Form.Item>,
     );
     return elements;
   }
@@ -132,7 +135,10 @@ export class MastodonFileSubmissionForm extends GenericFileSubmissionSection<Mas
           <Select.Option value="private">Followers Only</Select.Option>
           <Select.Option value="direct">Mentioned Users Only</Select.Option>
         </Select>
-      </Form.Item>
+      </Form.Item>,
+      <Form.Item label="Reply To Post URL">
+        <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+      </Form.Item>,
     );
     return elements;
   }


### PR DESCRIPTION
Allows specifying a reply to post URL for those two services, because I wanna be able to post threads. This interface isn't too comfortable, since it requires manual copying of the parent post URL. But letting your wire up a parent post from within PostyBirb is left as an exercise for someone else or future me, this is currently already useful as a minimum viable product.