### PR TITLE
Don't prepend space to first appended tag

### DIFF
--- a/electron-app/src/server/websites/website.base.ts
+++ b/electron-app/src/server/websites/website.base.ts
@@ -134,18 +134,25 @@ export abstract class Website {
    * Appends the tags to the description if there is enough character count available.
    */
   appendTags(tags: string[], description: string, limit: number) {
-    if (!tags.length || description.length + 4 > limit) return description;
-
-    description += '\n\n';
-
-    tags.forEach(tag => {
-      if (description.length + 1 + tag.length < limit) {
-        description += ` ${tag}`;
+    const appendedTags = [];
+    const appendToDescription = function (tag?: string): string {
+      const suffix = tag ? [...appendedTags, tag] : appendedTags;
+      if (suffix.length === 0) {
+        return description;
+      } else {
+        return description + '\n\n' + suffix.join(' ');
       }
-      // We don't exit the loop, so we can cram in every possible tag, even if there are short ones!
-    });
+    };
 
-    return description;
+    for (const tag of tags) {
+      if (appendToDescription(tag).length <= limit) {
+        appendedTags.push(tag);
+      }
+      // Keep looping over all tags even if one of them doesn't fit, we might
+      // find one that's short enough to cram in still.
+    }
+
+    return appendToDescription();
   }
 
   parseDescription(text: string, type?: SubmissionType): string {

--- a/electron-app/src/server/websites/website.base.ts
+++ b/electron-app/src/server/websites/website.base.ts
@@ -133,7 +133,12 @@ export abstract class Website {
   /**
    * Appends the tags to the description if there is enough character count available.
    */
-  appendTags(tags: string[], description: string, limit: number) {
+  appendTags(
+    tags: string[],
+    description: string,
+    limit: number,
+    getLength: (text: string) => number = (text) => text.length,
+  ): string {
     const appendedTags = [];
     const appendToDescription = function (tag?: string): string {
       const suffix = tag ? [...appendedTags, tag] : appendedTags;
@@ -145,7 +150,7 @@ export abstract class Website {
     };
 
     for (const tag of tags) {
-      if (appendToDescription(tag).length <= limit) {
+      if (getLength(appendToDescription(tag)) <= limit) {
         appendedTags.push(tag);
       }
       // Keep looping over all tags even if one of them doesn't fit, we might


### PR DESCRIPTION
Appending tags already puts two newlines at the end of the description, there's no need for another space. I think there was also an off-by-one in the length check here, allowing one less character than the limit, which is now rectified.

This applies to the generic website tag appender and also adds some special handling for Bluesky, which needs to do a special dance to do its character counting. This unifies the logic, getting rid of a pile of duplicate code in the Bluesky integration.