### PR TITLE
Fix Bluesky description length and alt text validation

### DIFF
--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -30,6 +30,7 @@ import { PlaintextParser } from 'src/server/description-parsing/plaintext/plaint
 import fetch from "node-fetch";
 import Graphemer from 'graphemer';
 import { ReplyRef } from '@atproto/api/dist/client/types/app/bsky/feed/post';
+import FormContent from 'src/server/utils/form-content.util';
 
 // Start of Polyfill
 
@@ -321,15 +322,7 @@ export class Bluesky extends Website {
       warnings.push(`Bluesky recommends alt text to be provided`);
     }
 
-    const rt = new RichText({ text: submissionPart.data.description.value });
-    const agent = new BskyAgent({ service: 'https://bsky.social' })
-    rt.detectFacets(agent);
-
-    if (rt.graphemeLength > this.MAX_CHARS) {
-      problems.push(
-        `Max description length allowed is ${this.MAX_CHARS} graphemes.`,
-      );
-    }
+    this.validateDescriptionLength(problems, submissionPart, defaultPart);
 
     const files = [
       submission.primary,
@@ -386,19 +379,30 @@ export class Bluesky extends Website {
     const problems: string[] = [];
     const warnings: string[] = [];
 
-    const rt = new RichText({ text: submissionPart.data.description.value });
+    this.validateDescriptionLength(problems, submissionPart, defaultPart);
+    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
+
+    return { problems, warnings };
+  }
+
+  private validateDescriptionLength(
+    problems: string[],
+    submissionPart: SubmissionPart<BlueskyNotificationOptions>,
+    defaultPart: SubmissionPart<DefaultOptions>,
+  ): void {
+    const description = this.defaultDescriptionParser(
+      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
+    );
+
+    const rt = new RichText({ text: description });
     const agent = new BskyAgent({ service: 'https://bsky.social' })
     rt.detectFacets(agent);
 
     if (rt.graphemeLength > this.MAX_CHARS) {
       problems.push(
-        `Max description length allowed is ${this.MAX_CHARS} graphemes.`,
+        `Max description length allowed is ${this.MAX_CHARS} characters.`,
       );
     }
-
-    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
-
-    return { problems, warnings };
   }
 
   private validateReplyToUrl(problems: string[], url?: string): void {

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -319,7 +319,10 @@ export class Bluesky extends Website {
     const isAutoscaling: boolean = submissionPart.data.autoScale;
 
     if (!submissionPart.data.altText) {
-      warnings.push(`Bluesky recommends alt text to be provided`);
+      problems.push(
+        'Bluesky currently always requires alt text to be provided, ' +
+          'even if your settings say otherwise. This is a bug on their side.',
+      );
     }
 
     this.validateDescriptionLength(problems, submissionPart, defaultPart);


### PR DESCRIPTION
Properly validate Bluesky description length, it wasn't using the plain text version of the description, so its character count was inflated by counting the raw HTML. This is rectified now, by using the same kind of code that other services use.

The error message also now says "characters" again instead of "graphemes", since graphemes are what humans interpret as characters, even if the computer may see them as a collection of characters.

Require alt text for Bluesky again, with an explanation that that's a bug on their side in the hopes that it will stop people reporting it to PostyBirb's side.

cc @aneillans