### PR TITLE
Itaku: Add a 5000 char description limit on validation

### DIFF
--- a/electron-app/src/server/websites/itaku/itaku.service.ts
+++ b/electron-app/src/server/websites/itaku/itaku.service.ts
@@ -231,7 +231,12 @@ export class Itaku extends Website {
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
-    const isAutoscaling: boolean = submissionPart.data.autoScale;
+    
+    if (defaultPart.data.description.value.length > 5000) {
+      problems.push(
+        `Max description length allowed is 5000 characters.`,
+      );
+    }
 
     if (FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags).length < 5) {
       problems.push('Requires at least 5 tags.');


### PR DESCRIPTION
As mentioned on Discord, it appears Itaku has a 5000 character limit on descriptions; added this to the validation as a problem