### PR TITLE
fix: Description Length Limit

### DIFF
--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -24,6 +24,7 @@ import { LoginResponse } from '../interfaces/login-response.interface';
 import { ScalingOptions } from '../interfaces/scaling-options.interface';
 import { Website } from '../website.base';
 import { PostData } from '../../submission/post/interfaces/post-data.interface';
+import FormContent from "../../utils/form-content.util";
 
 @Injectable()
 export class Artconomy extends Website {
@@ -249,6 +250,13 @@ export class Artconomy extends Website {
           'clothing/accessories, ' +
           'relationships depicted',
       );
+    }
+    const description = this.defaultDescriptionParser(
+      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
+    )
+
+    if (description.length > 2000) {
+      problems.push('Description must be 2000 characters or fewer.')
     }
 
     const maxMB = 99;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release:linux": "node create-signer.js && npm run make && cd electron-app && yarn run release:linux",
     "release:osx": "npm run make && cd electron-app && yarn run release:osx",
     "contribute": "npm ci --ignore-scripts && run-p --silent --print-name ci:** && run-p build:**",
-    "contribute:debug": "npm ci --ignore-scripts && run-p --print-name ci:** && --print-label run-p build:**",
+    "contribute:debug": "npm ci --ignore-scripts && run-p --print-name ci:** && run-p build:**",
     "ci:commons": "cd commons && npm ci --no-audit&& npm run build",
     "ci:app": "cd electron-app && npm ci --no-audit",
     "ci:ui": "cd ui && npm ci --no-audit --no-fund --no-deprecate",


### PR DESCRIPTION
This PR adds a check for descriptions which exceed the 2000 character limit imposed by Artconomy, providing an error when present.

**Testing instructions**:

1. Log into an Artconomy account
2. Create a file submission
3. Enter a default description with a length over 2000 characters
4. Verify error message shown upon save
5. Replace default description with one that is shorter than 2000 characters
6. Add a description override for Artconomy with a length greater than 2000 characters
7. Verify error message shown upon save