### PR TITLE
Megalodon refactor

### DIFF
--- a/commons/package-lock.json
+++ b/commons/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^14.11.1",
         "class-transformer": "^0.3.1",
         "class-validator": "^0.12.2",
-        "megalodon": "^6.2.0"
+        "megalodon": "^7.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -21,9 +21,9 @@
       "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
     },
     "node_modules/@types/oauth": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
-      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.2.tgz",
+      "integrity": "sha512-Nu3/abQ6yR9VlsCdX3aiGsWFkj6OJvJqDvg/36t8Gwf2mFXdBZXPDN3K+2yfeA6Lo2m1Q12F8Qil9TZ48nWhOQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -58,9 +58,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -181,23 +181,23 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/megalodon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-6.2.0.tgz",
-      "integrity": "sha512-OTnZ8zcg9fhYMTbGDTDEOunSA0/zIqzEu03Ne925aTaAqL7i4gnxiwBHrRusPcA7JS4wnuicAYuwuOXZVrDK0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-7.0.1.tgz",
+      "integrity": "sha512-zJhYXw+FNaNkjpY8uJo+C4u6p2yxdPYRmnY4tMY1/kQQca9ZdqvP9a9sT4Yiv7uvQPxwXLjVeWNqWQefkBwT1A==",
       "dependencies": {
-        "@types/oauth": "^0.9.0",
+        "@types/oauth": "^0.9.2",
         "@types/ws": "^8.5.5",
-        "axios": "1.4.0",
+        "axios": "1.5.0",
         "dayjs": "^1.11.9",
         "form-data": "^4.0.0",
-        "https-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.2",
         "oauth": "^0.10.0",
         "object-assign-deep": "^0.4.0",
         "parse-link-header": "^2.0.0",
-        "socks-proxy-agent": "^8.0.1",
+        "socks-proxy-agent": "^8.0.2",
         "typescript": "5.1.6",
-        "uuid": "^9.0.0",
-        "ws": "8.13.0"
+        "uuid": "^9.0.1",
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=15.0.0"
@@ -276,11 +276,11 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
-      "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
       "dependencies": {
-        "agent-base": "^7.0.1",
+        "agent-base": "^7.0.2",
         "debug": "^4.3.4",
         "socks": "^2.7.1"
       },
@@ -306,9 +306,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -322,9 +326,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -357,9 +361,9 @@
       "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
     },
     "@types/oauth": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
-      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.2.tgz",
+      "integrity": "sha512-Nu3/abQ6yR9VlsCdX3aiGsWFkj6OJvJqDvg/36t8Gwf2mFXdBZXPDN3K+2yfeA6Lo2m1Q12F8Qil9TZ48nWhOQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -391,9 +395,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -443,9 +447,9 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -477,23 +481,23 @@
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "megalodon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-6.2.0.tgz",
-      "integrity": "sha512-OTnZ8zcg9fhYMTbGDTDEOunSA0/zIqzEu03Ne925aTaAqL7i4gnxiwBHrRusPcA7JS4wnuicAYuwuOXZVrDK0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-7.0.1.tgz",
+      "integrity": "sha512-zJhYXw+FNaNkjpY8uJo+C4u6p2yxdPYRmnY4tMY1/kQQca9ZdqvP9a9sT4Yiv7uvQPxwXLjVeWNqWQefkBwT1A==",
       "requires": {
-        "@types/oauth": "^0.9.0",
+        "@types/oauth": "^0.9.2",
         "@types/ws": "^8.5.5",
-        "axios": "1.4.0",
+        "axios": "1.5.0",
         "dayjs": "^1.11.9",
         "form-data": "^4.0.0",
-        "https-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.2",
         "oauth": "^0.10.0",
         "object-assign-deep": "^0.4.0",
         "parse-link-header": "^2.0.0",
-        "socks-proxy-agent": "^8.0.1",
+        "socks-proxy-agent": "^8.0.2",
         "typescript": "5.1.6",
-        "uuid": "^9.0.0",
-        "ws": "8.13.0"
+        "uuid": "^9.0.1",
+        "ws": "8.14.2"
       }
     },
     "mime-db": {
@@ -552,11 +556,11 @@
       }
     },
     "socks-proxy-agent": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
-      "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
       "requires": {
-        "agent-base": "^7.0.1",
+        "agent-base": "^7.0.2",
         "debug": "^4.3.4",
         "socks": "^2.7.1"
       }
@@ -572,9 +576,9 @@
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "validator": {
       "version": "13.0.0",
@@ -582,9 +586,9 @@
       "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
     },
     "ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "requires": {}
     },
     "xtend": {

--- a/commons/package.json
+++ b/commons/package.json
@@ -14,6 +14,6 @@
     "@types/node": "^14.11.1",
     "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",
-    "megalodon": "^6.2.0"
+    "megalodon": "^7.0.0"
   }
 }

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -66,6 +66,9 @@ export * from './interfaces/websites/mastodon/mastodon.notification.options.inte
 export * from './interfaces/websites/misskey/misskey.account.interface';
 export * from './interfaces/websites/misskey/misskey.file.options.interface';
 export * from './interfaces/websites/misskey/misskey.notification.options.interface';
+export * from './interfaces/websites/pleroma/pleroma.account.interface';
+export * from './interfaces/websites/pleroma/pleroma.file.options.interface';
+export * from './interfaces/websites/pleroma/pleroma.notification.options.interface';
 export * from './interfaces/websites/newgrounds/newgrounds.file.options.interface';
 export * from './interfaces/websites/patreon/patreon.file.options.interface';
 export * from './interfaces/websites/patreon/patreon.notification.options.interface';

--- a/commons/src/index.ts
+++ b/commons/src/index.ts
@@ -60,13 +60,12 @@ export * from './interfaces/websites/hentai-foundry/hentai-foundry.file.options.
 export * from './interfaces/websites/inkbunny/inkbunny.file.options.interface';
 export * from './interfaces/websites/ko-fi/ko-fi.file.options.interface';
 export * from './interfaces/websites/manebooru/manebooru.file.options.interface';
-export * from './interfaces/websites/mastodon/mastodon.account.interface';
+export * from './interfaces/websites/megalodon/megalodon.account.interface';
 export * from './interfaces/websites/mastodon/mastodon.file.options.interface';
 export * from './interfaces/websites/mastodon/mastodon.notification.options.interface';
 export * from './interfaces/websites/misskey/misskey.account.interface';
 export * from './interfaces/websites/misskey/misskey.file.options.interface';
 export * from './interfaces/websites/misskey/misskey.notification.options.interface';
-export * from './interfaces/websites/pleroma/pleroma.account.interface';
 export * from './interfaces/websites/pleroma/pleroma.file.options.interface';
 export * from './interfaces/websites/pleroma/pleroma.notification.options.interface';
 export * from './interfaces/websites/newgrounds/newgrounds.file.options.interface';
@@ -91,7 +90,6 @@ export * from './interfaces/websites/itaku/itaku.notification.options.interface'
 export * from './interfaces/websites/telegram/telegram.account.interface';
 export * from './interfaces/websites/telegram/telegram.file.options.interface';
 export * from './interfaces/websites/telegram/telegram.notification.options.interface';
-export * from './interfaces/websites/pixelfed/pixelfed.account.interface';
 export * from './interfaces/websites/pixelfed/pixelfed.file.options.interface';
 export * from './interfaces/websites/bluesky/bluesky.account.interface';
 export * from './interfaces/websites/bluesky/bluesky.file.options.interface';

--- a/commons/src/interfaces/websites/megalodon/megalodon.account.interface.ts
+++ b/commons/src/interfaces/websites/megalodon/megalodon.account.interface.ts
@@ -1,4 +1,4 @@
-export interface MastodonAccountData {
+export interface MegalodonAccountData {
   token: string;
   website: string;
   username: string;

--- a/commons/src/interfaces/websites/pixelfed/pixelfed.account.interface.ts
+++ b/commons/src/interfaces/websites/pixelfed/pixelfed.account.interface.ts
@@ -1,5 +1,0 @@
-export interface PixelfedAccountData {
-  token: string;
-  website: string;
-  username: string;
-}

--- a/commons/src/interfaces/websites/pleroma/pleroma.account.interface.ts
+++ b/commons/src/interfaces/websites/pleroma/pleroma.account.interface.ts
@@ -1,0 +1,6 @@
+import { OAuth } from 'megalodon'
+export interface PleromaAccountData {
+  tokenData: OAuth.TokenData | null;
+  website: string;
+  username: string;
+}

--- a/commons/src/interfaces/websites/pleroma/pleroma.account.interface.ts
+++ b/commons/src/interfaces/websites/pleroma/pleroma.account.interface.ts
@@ -1,6 +1,0 @@
-import { OAuth } from 'megalodon'
-export interface PleromaAccountData {
-  tokenData: OAuth.TokenData | null;
-  website: string;
-  username: string;
-}

--- a/commons/src/interfaces/websites/pleroma/pleroma.file.options.interface.ts
+++ b/commons/src/interfaces/websites/pleroma/pleroma.file.options.interface.ts
@@ -1,0 +1,9 @@
+import { DefaultFileOptions } from '../../submission/default-options.interface';
+
+export interface PleromaFileOptions extends DefaultFileOptions {
+  useTitle: boolean;
+  spoilerText?: string;
+  visibility: string;
+  altText?: string;
+  replyToUrl?: string;
+}

--- a/commons/src/interfaces/websites/pleroma/pleroma.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/pleroma/pleroma.notification.options.interface.ts
@@ -1,0 +1,8 @@
+import { DefaultOptions } from '../../submission/default-options.interface';
+
+export interface PleromaNotificationOptions extends DefaultOptions {
+  useTitle: boolean;
+  spoilerText?: string;
+  visibility: string;
+  replyToUrl?: string;
+}

--- a/commons/src/websites/pleroma/pleroma.file.options.ts
+++ b/commons/src/websites/pleroma/pleroma.file.options.ts
@@ -1,0 +1,38 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { DefaultFileOptions } from '../../interfaces/submission/default-options.interface';
+import { PleromaFileOptions } from '../../interfaces/websites/pleroma/pleroma.file.options.interface';
+import { DefaultValue } from '../../models/decorators/default-value.decorator';
+import { DefaultFileOptionsEntity } from '../../models/default-file-options.entity';
+
+export class PleromaFileOptionsEntity extends DefaultFileOptionsEntity
+  implements PleromaFileOptions {
+  @Expose()
+  @IsBoolean()
+  @DefaultValue(false)
+  useTitle!: boolean;
+
+  @Expose()
+  @IsOptional()
+  @IsString()
+  spoilerText?: string;
+  
+  @Expose()
+  @IsString()
+  @DefaultValue('public')
+  visibility!: string;
+
+  @Expose()
+  @IsOptional()
+  @IsString()
+  altText?: string;
+  
+  @Expose()
+  @IsOptional()
+  @IsString()
+  replyToUrl?: string;
+
+  constructor(entity?: Partial<PleromaFileOptions>) {
+    super(entity as DefaultFileOptions);
+  }
+}

--- a/commons/src/websites/pleroma/pleroma.notification.options.ts
+++ b/commons/src/websites/pleroma/pleroma.notification.options.ts
@@ -1,0 +1,33 @@
+import { Expose } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { DefaultOptions } from '../../interfaces/submission/default-options.interface';
+import { PleromaNotificationOptions } from '../../interfaces/websites/pleroma/pleroma.notification.options.interface';
+import { DefaultValue } from '../../models/decorators/default-value.decorator';
+import { DefaultOptionsEntity } from '../../models/default-options.entity';
+
+export class PleromaNotificationOptionsEntity extends DefaultOptionsEntity
+  implements PleromaNotificationOptions {
+  @Expose()
+  @IsBoolean()
+  @DefaultValue(false)
+  useTitle!: boolean;
+
+  @Expose()
+  @IsOptional()
+  @IsString()
+  spoilerText?: string;
+
+  @Expose()
+  @IsString()
+  @DefaultValue('public')
+  visibility!: string;
+
+  @Expose()
+  @IsOptional()
+  @IsString()
+  replyToUrl?: string;
+
+  constructor(entity?: Partial<PleromaNotificationOptions>) {
+    super(entity as DefaultOptions);
+  }
+}

--- a/commons/src/websites/pleroma/pleroma.options.ts
+++ b/commons/src/websites/pleroma/pleroma.options.ts
@@ -1,0 +1,7 @@
+import { PleromaFileOptionsEntity } from './pleroma.file.options';
+import { PleromaNotificationOptionsEntity } from './pleroma.notification.options';
+
+export class Pleroma {
+  static readonly FileOptions = PleromaFileOptionsEntity;
+  static readonly NotificationOptions = PleromaNotificationOptionsEntity;
+}

--- a/commons/src/websites/websites.ts
+++ b/commons/src/websites/websites.ts
@@ -14,6 +14,7 @@ export * from './ko-fi/ko-fi.options';
 export * from './manebooru/manebooru.options';
 export * from './mastodon/mastodon.options';
 export * from './misskey/misskey.options';
+export * from './pleroma/pleroma.options';
 export * from './newgrounds/newgrounds.options';
 export * from './patreon/patreon.options';
 export * from './picarto/picarto.options';

--- a/electron-app/package-lock.json
+++ b/electron-app/package-lock.json
@@ -35,7 +35,7 @@
         "jimp": "^0.16.1",
         "lodash": "^4.17.20",
         "lowdb": "^1.0.0",
-        "megalodon": "^6.2.0",
+        "megalodon": "^7.0.0",
         "nanoid": "^2.1.8",
         "nedb": "^1.8.0",
         "node-fetch": "^2.6.12",
@@ -89,7 +89,7 @@
         "@types/node": "^14.11.1",
         "class-transformer": "^0.3.1",
         "class-validator": "^0.12.2",
-        "megalodon": "^6.2.0"
+        "megalodon": "^7.0.0"
       }
     },
     "../commons/node_modules/@types/node": {
@@ -20150,23 +20150,23 @@
       }
     },
     "node_modules/megalodon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-6.2.0.tgz",
-      "integrity": "sha512-OTnZ8zcg9fhYMTbGDTDEOunSA0/zIqzEu03Ne925aTaAqL7i4gnxiwBHrRusPcA7JS4wnuicAYuwuOXZVrDK0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-7.0.1.tgz",
+      "integrity": "sha512-zJhYXw+FNaNkjpY8uJo+C4u6p2yxdPYRmnY4tMY1/kQQca9ZdqvP9a9sT4Yiv7uvQPxwXLjVeWNqWQefkBwT1A==",
       "dependencies": {
-        "@types/oauth": "^0.9.0",
+        "@types/oauth": "^0.9.2",
         "@types/ws": "^8.5.5",
-        "axios": "1.4.0",
+        "axios": "1.5.0",
         "dayjs": "^1.11.9",
         "form-data": "^4.0.0",
-        "https-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.2",
         "oauth": "^0.10.0",
         "object-assign-deep": "^0.4.0",
         "parse-link-header": "^2.0.0",
-        "socks-proxy-agent": "^8.0.1",
+        "socks-proxy-agent": "^8.0.2",
         "typescript": "5.1.6",
-        "uuid": "^9.0.0",
-        "ws": "8.13.0"
+        "uuid": "^9.0.1",
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=15.0.0"
@@ -20184,9 +20184,9 @@
       }
     },
     "node_modules/megalodon/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -20256,9 +20256,9 @@
       }
     },
     "node_modules/megalodon/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -43023,23 +43023,23 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "megalodon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-6.2.0.tgz",
-      "integrity": "sha512-OTnZ8zcg9fhYMTbGDTDEOunSA0/zIqzEu03Ne925aTaAqL7i4gnxiwBHrRusPcA7JS4wnuicAYuwuOXZVrDK0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-7.0.1.tgz",
+      "integrity": "sha512-zJhYXw+FNaNkjpY8uJo+C4u6p2yxdPYRmnY4tMY1/kQQca9ZdqvP9a9sT4Yiv7uvQPxwXLjVeWNqWQefkBwT1A==",
       "requires": {
-        "@types/oauth": "^0.9.0",
+        "@types/oauth": "^0.9.2",
         "@types/ws": "^8.5.5",
-        "axios": "1.4.0",
+        "axios": "1.5.0",
         "dayjs": "^1.11.9",
         "form-data": "^4.0.0",
-        "https-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.2",
         "oauth": "^0.10.0",
         "object-assign-deep": "^0.4.0",
         "parse-link-header": "^2.0.0",
-        "socks-proxy-agent": "^8.0.1",
+        "socks-proxy-agent": "^8.0.2",
         "typescript": "5.1.6",
-        "uuid": "^9.0.0",
-        "ws": "8.13.0"
+        "uuid": "^9.0.1",
+        "ws": "8.14.2"
       },
       "dependencies": {
         "agent-base": {
@@ -43051,9 +43051,9 @@
           }
         },
         "axios": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+          "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
           "requires": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -43098,9 +43098,9 @@
           "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         },
         "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
           "requires": {}
         }
       }
@@ -44886,7 +44886,7 @@
         "@types/node": "^14.11.1",
         "class-transformer": "^0.3.1",
         "class-validator": "^0.12.2",
-        "megalodon": "^6.2.0"
+        "megalodon": "^7.0.0"
       },
       "dependencies": {
         "@types/node": {

--- a/electron-app/package-lock.json
+++ b/electron-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postybirb-plus",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postybirb-plus",
-      "version": "3.1.30",
+      "version": "3.1.31",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -62,7 +62,7 @@
     "jimp": "^0.16.1",
     "lodash": "^4.17.20",
     "lowdb": "^1.0.0",
-    "megalodon": "^6.2.0",
+    "megalodon": "^7.0.0",
     "nanoid": "^2.1.8",
     "nedb": "^1.8.0",
     "node-fetch": "^2.6.12",

--- a/electron-app/src/server/websites/mastodon/mastodon.service.ts
+++ b/electron-app/src/server/websites/mastodon/mastodon.service.ts
@@ -1,38 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import generator, { Entity, Response } from 'megalodon';
 import {
-  DefaultOptions,
   FileRecord,
-  FileSubmission,
   FileSubmissionType,
-  MegalodonAccountData,
-  MastodonFileOptions,
-  MastodonNotificationOptions,
-  PostResponse,
-  Submission,
-  SubmissionPart,
-  SubmissionRating,
 } from 'postybirb-commons';
 import { ScalingOptions } from '../interfaces/scaling-options.interface';
-import UserAccountEntity from 'src/server//account/models/user-account.entity';
-import { PlaintextParser } from 'src/server/description-parsing/plaintext/plaintext.parser';
-import ImageManipulator from 'src/server/file-manipulation/manipulators/image.manipulator';
-import Http from 'src/server/http/http.util';
-import { CancellationToken } from 'src/server/submission/post/cancellation/cancellation-token';
-import {
-  FilePostData,
-  PostFile,
-} from 'src/server/submission/post/interfaces/file-post-data.interface';
-import { PostData } from 'src/server/submission/post/interfaces/post-data.interface';
-import { ValidationParts } from 'src/server/submission/validator/interfaces/validation-parts.interface';
-import FileSize from 'src/server/utils/filesize.util';
-import FormContent from 'src/server/utils/form-content.util';
-import WebsiteValidator from 'src/server/utils/website-validator.util';
-import { LoginResponse } from '../interfaces/login-response.interface';
-import { Website } from '../website.base';
 import _ from 'lodash';
-import WaitUtil from 'src/server/utils/wait.util';
-import { FileManagerService } from 'src/server/file-manager/file-manager.service';
 import { Megalodon } from '../megalodon/megalodon.service';
 
 const INFO_KEY = 'INSTANCE INFO';
@@ -85,6 +57,13 @@ export class Mastodon extends Megalodon {
     'wma',
   ];
 
+  getInstanceSettings(accountId: string) {
+    const instanceInfo: MastodonInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
+
+    this.maxCharLength = instanceInfo?.configuration?.statuses?.max_characters ?? 500;
+    this.maxMediaCount = instanceInfo ? instanceInfo?.configuration?.statuses?.max_media_attachments : 4;
+  }
+
   getScalingOptions(file: FileRecord, accountId: string): ScalingOptions {
     const instanceInfo: MastodonInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
     if (instanceInfo?.configuration?.media_attachments) {
@@ -104,208 +83,6 @@ export class Mastodon extends Megalodon {
     } else {
       return undefined;
     }
-  }
-
-  async postFileSubmission(
-    cancellationToken: CancellationToken,
-    data: FilePostData<MastodonFileOptions>,
-    accountData: MegalodonAccountData,
-  ): Promise<PostResponse> {
-    const M = generator('mastodon', accountData.website, accountData.token);
-
-    const files = [data.primary, ...data.additional];
-    const uploadedMedias: {
-      id: string;
-    }[] = [];
-    for (const file of files) {
-      this.checkCancelled(cancellationToken);
-      uploadedMedias.push(await this.uploadMedia(accountData, file.file, data.options.altText));
-    }
-
-    const instanceInfo: MastodonInstanceInfo = this.getAccountInfo(data.part.accountId, INFO_KEY);
-    const chunkCount = instanceInfo ? instanceInfo?.configuration?.statuses?.max_media_attachments : 4;
-
-    const isSensitive = data.rating !== SubmissionRating.GENERAL;
-    const chunks = _.chunk(uploadedMedias, chunkCount);
-    let status = `${data.options.useTitle && data.title ? `${data.title}\n` : ''}${
-      data.description
-    }`.substring(0, this.maxCharLength);
-    let lastId = '';
-    let source = '';
-    const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
-
-    for (let i = 0; i < chunks.length; i++) {
-      this.checkCancelled(cancellationToken);
-      const statusOptions: any = {
-        sensitive: isSensitive,
-        visibility: data.options.visibility || 'public',
-        media_ids: chunks[i],
-      };
-
-      if (i !== 0) {
-        statusOptions.in_reply_to_id = lastId;
-      } else if (replyToId) {
-        statusOptions.in_reply_to_id = replyToId;
-      }
-
-      if (data.options.spoilerText) {
-        statusOptions.spoiler_text = data.options.spoilerText;
-      }
-
-      status = this.appendTags(this.formatTags(data.tags), status, this.maxCharLength);
-
-      try {
-        const result = (await M.postStatus(status, statusOptions)).data as Entity.Status;
-        if (!source) source = result.url;
-        lastId = result.id;
-      } catch (err) {
-        return Promise.reject(
-          this.createPostResponse({
-            message: err.message,
-            stack: err.stack,
-            additionalInfo: { chunkNumber: i },
-          }),
-        );
-      }
-    }
-
-    this.checkCancelled(cancellationToken);
-
-    return this.createPostResponse({ source });
-  }
-
-  async postNotificationSubmission(
-    cancellationToken: CancellationToken,
-    data: PostData<Submission, MastodonNotificationOptions>,
-    accountData: MegalodonAccountData,
-  ): Promise<PostResponse> {
-    const M = generator('mastodon', accountData.website, accountData.token);
-    const instanceInfo: MastodonInstanceInfo = this.getAccountInfo(data.part.accountId, INFO_KEY);
-    const maxChars = instanceInfo?.configuration?.statuses?.max_characters ?? 500;
-
-    const isSensitive = data.rating !== SubmissionRating.GENERAL;
-    const statusOptions: any = {
-      sensitive: isSensitive,
-      visibility: data.options.visibility || 'public',
-    };
-    let status = `${data.options.useTitle && data.title ? `${data.title}\n` : ''}${
-      data.description
-    }`;
-    if (data.options.spoilerText) {
-      statusOptions.spoiler_text = data.options.spoilerText;
-    }
-    status = this.appendTags(this.formatTags(data.tags), status, maxChars);
-
-    const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
-    if (replyToId) {
-      statusOptions.in_reply_to_id = replyToId;
-    }
-
-    this.checkCancelled(cancellationToken);
-    try {
-      const result = (await M.postStatus(status, statusOptions)).data as Entity.Status;
-      return this.createPostResponse({ source: result.url });
-    } catch (error) {
-      return Promise.reject(this.createPostResponse(error));
-    }
-  }
-
-  formatTags(tags: string[]) {
-    return this.parseTags(
-      tags
-        .map(tag => tag.replace(/[^a-z0-9]/gi, ' '))
-        .map(tag =>
-          tag
-            .split(' ')
-            // .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(''),
-        ),
-      { spaceReplacer: '_' },
-    ).map(tag => `#${tag}`);
-  }
-
-  validateFileSubmission(
-    submission: FileSubmission,
-    submissionPart: SubmissionPart<MastodonFileOptions>,
-    defaultPart: SubmissionPart<DefaultOptions>,
-  ): ValidationParts {
-    const problems: string[] = [];
-    const warnings: string[] = [];
-    const isAutoscaling: boolean = submissionPart.data.autoScale;
-
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    const instanceInfo: MastodonInstanceInfo = this.getAccountInfo(
-      submissionPart.accountId,
-      INFO_KEY,
-    );
-    const maxChars = instanceInfo?.configuration?.statuses?.max_characters ?? 500;
-
-    if (description.length > maxChars) {
-      warnings.push(
-        `Max description length allowed is ${maxChars} characters (for this instance).`,
-      );
-    }
-
-    const files = [
-      submission.primary,
-      ...(submission.additional || []).filter(
-        f => !f.ignoredAccounts!.includes(submissionPart.accountId),
-      ),
-    ];
-
-    files.forEach(file => {
-      const { type, size, name, mimetype } = file;
-      if (!WebsiteValidator.supportsFileType(file, this.acceptsFiles)) {
-        problems.push(`Does not support file format: (${name}) ${mimetype}.`);
-      }
-
-      const scalingOptions = this.getScalingOptions(file, submissionPart.accountId);
-
-      if (scalingOptions && scalingOptions.maxSize < size) {
-        if (
-          isAutoscaling &&
-          type === FileSubmissionType.IMAGE &&
-          ImageManipulator.isMimeType(mimetype)
-        ) {
-          warnings.push(
-            `${name} will be scaled down to ${FileSize.BytesToMB(scalingOptions.maxSize)}MB`,
-          );
-        } else {
-          problems.push(
-            `This instance limits ${mimetype} to ${FileSize.BytesToMB(scalingOptions.maxSize)}MB`,
-          );
-        }
-      }
-
-      if (
-        scalingOptions &&
-        isAutoscaling &&
-        type === FileSubmissionType.IMAGE &&
-        scalingOptions.maxWidth &&
-        scalingOptions.maxHeight &&
-        (file.height > scalingOptions.maxHeight || file.width > scalingOptions.maxWidth)
-      ) {
-        warnings.push(
-          `${name} will be scaled down to a maximum size of ${scalingOptions.maxWidth}x${scalingOptions.maxHeight}, while maintaining aspect ratio`,
-        );
-      }
-    });
-
-    if (
-      (submissionPart.data.tags.value.length > 1 || defaultPart.data.tags.value.length > 1) &&
-      submissionPart.data.visibility != 'public'
-    ) {
-      warnings.push(
-        `This post won't be listed under any hashtag as it is not public. Only public posts can be searched by hashtag.`,
-      );
-    }
-
-    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
-
-    return { problems, warnings };
   }
 
   getPostIdFromUrl(url: string): string | null {

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -41,7 +41,7 @@ export abstract class Megalodon extends Website {
     super();
   }
 
-  readonly megalodonService = 'mastodon'; // Set this as appropriate in your constructor
+  megalodonService: 'mastodon' | 'pleroma' | 'misskey' | 'friendica' = 'mastodon'; // Set this as appropriate in your constructor
   maxCharLength = 500; // Set this off the instance information!
   maxMediaCount = 4; 
 

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -1,4 +1,4 @@
-import generator, { Entity, Response } from 'megalodon';
+import generator, { Entity } from 'megalodon';
 import {
   DefaultOptions,
   FileRecord,
@@ -63,6 +63,7 @@ export abstract class Megalodon extends Website {
   async checkLoginStatus(data: UserAccountEntity): Promise<LoginResponse> {
     const status: LoginResponse = { loggedIn: false, username: null };
     const accountData: MegalodonAccountData = data.data;
+    this.logger.debug(`Login check: ${data._id} = ${accountData.website}`);
     if (accountData && accountData.token) {
       await this.getAndStoreInstanceInfo(data._id, accountData);
 

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -81,34 +81,7 @@ export abstract class Megalodon extends Website {
     this.storeAccountInformation(profileId, INFO_KEY, instance.data);
   }
 
-  // TODO: Refactor
-
-  getScalingOptions(file: FileRecord, accountId: string): ScalingOptions {
-    const instanceInfo: MastodonInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
-    if (instanceInfo?.configuration?.media_attachments) {
-      const maxPixels =
-        file.type === FileSubmissionType.IMAGE
-          ? instanceInfo.configuration.media_attachments.image_matrix_limit
-          : instanceInfo.configuration.media_attachments.video_matrix_limit;
-
-      return {
-        maxHeight: Math.round(Math.sqrt(maxPixels * (file.width / file.height))),
-        maxWidth: Math.round(Math.sqrt(maxPixels * (file.height / file.width))),
-        maxSize:
-          file.type === FileSubmissionType.IMAGE
-            ? instanceInfo.configuration.media_attachments.image_size_limit
-            : instanceInfo.configuration.media_attachments.video_size_limit,
-      };
-    } else if (instanceInfo?.upload_limit) {
-      return {
-        maxSize: instanceInfo?.upload_limit,
-      };
-    } else {
-      return undefined;
-    }
-  }
-
-  // TODO: Add common uploadMedia code from Pleroma codebase
+  abstract getScalingOptions(file: FileRecord, accountId: string): ScalingOptions;
 
   // TODO: Refactor
 
@@ -120,7 +93,9 @@ export abstract class Megalodon extends Website {
     const M = generator('mastodon', accountData.website, accountData.token);
 
     const files = [data.primary, ...data.additional];
-    const uploadedMedias: string[] = [];
+    const uploadedMedias: {
+        id: string;
+      }[] = [];
     for (const file of files) {
       this.checkCancelled(cancellationToken);
       uploadedMedias.push(await this.uploadMedia(accountData, file.file, data.options.altText));

--- a/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
+++ b/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import generator, { Entity, Response } from 'megalodon';
+import generator, { Entity } from 'megalodon';
 import {
   DefaultOptions,
   FileRecord,
@@ -8,7 +8,6 @@ import {
   MegalodonAccountData,
   PixelfedFileOptions,
   PostResponse,
-  Submission,
   SubmissionPart,
   SubmissionRating,
 } from 'postybirb-commons';

--- a/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
+++ b/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
@@ -5,7 +5,7 @@ import {
   FileRecord,
   FileSubmission,
   FileSubmissionType,
-  PixelfedAccountData,
+  MegalodonAccountData,
   PixelfedFileOptions,
   PostResponse,
   Submission,
@@ -62,7 +62,7 @@ export class Pixelfed extends Website {
 
   async checkLoginStatus(data: UserAccountEntity): Promise<LoginResponse> {
     const status: LoginResponse = { loggedIn: false, username: null };
-    const accountData: PixelfedAccountData = data.data;
+    const accountData: MegalodonAccountData = data.data;
     if (accountData && accountData.token) {
       const refresh = await this.refreshToken(accountData);
       if (refresh) {
@@ -74,7 +74,7 @@ export class Pixelfed extends Website {
     return status;
   }
 
-  private async getInstanceInfo(profileId: string, data: PixelfedAccountData) {
+  private async getInstanceInfo(profileId: string, data: MegalodonAccountData) {
     const client = generator('mastodon', data.website, data.token);
     const instance = await client.getInstance();
 
@@ -82,12 +82,12 @@ export class Pixelfed extends Website {
   }
 
   // TBH not entirely sure why this is a thing, but its in the old code so... :shrug:
-  private async refreshToken(data: PixelfedAccountData): Promise<boolean> {
+  private async refreshToken(data: MegalodonAccountData): Promise<boolean> {
     const M = this.getPixelfedInstance(data);
     return true;
   }
 
-  private getPixelfedInstance(data: PixelfedAccountData): Entity.Instance {
+  private getPixelfedInstance(data: MegalodonAccountData): Entity.Instance {
     const client = generator('mastodon', data.website, data.token);
     client.getInstance().then(res => {
       return res.data;
@@ -114,7 +114,7 @@ export class Pixelfed extends Website {
   }
 
   private async uploadMedia(
-    data: PixelfedAccountData,
+    data: MegalodonAccountData,
     file: PostFile,
     altText: string,
   ): Promise<{ id: string }> {
@@ -173,7 +173,7 @@ export class Pixelfed extends Website {
   async postFileSubmission(
     cancellationToken: CancellationToken,
     data: FilePostData<PixelfedFileOptions>,
-    accountData: PixelfedAccountData,
+    accountData: MegalodonAccountData,
   ): Promise<PostResponse> {
     const M = generator('mastodon', accountData.website, accountData.token);
 

--- a/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
+++ b/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
@@ -59,6 +59,10 @@ export class Pixelfed extends Megalodon {
 
   // https://{instance}/i/web/post/{id}
   getPostIdFromUrl(url: string): string | null {
-    return url.slice(url.lastIndexOf('/') + 1);
+    if (url && url.lastIndexOf('/') > -1) {
+      return url.slice(url.lastIndexOf('/') + 1);
+    } else { 
+      return null;
+    }
   }
 }

--- a/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
+++ b/electron-app/src/server/websites/pixelfed/pixelfed.service.ts
@@ -1,36 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import generator, { Entity } from 'megalodon';
 import {
-  DefaultOptions,
   FileRecord,
-  FileSubmission,
   FileSubmissionType,
-  MegalodonAccountData,
-  PixelfedFileOptions,
-  PostResponse,
-  SubmissionPart,
-  SubmissionRating,
 } from 'postybirb-commons';
 import { ScalingOptions } from '../interfaces/scaling-options.interface';
-import UserAccountEntity from 'src/server//account/models/user-account.entity';
-import { PlaintextParser } from 'src/server/description-parsing/plaintext/plaintext.parser';
-import ImageManipulator from 'src/server/file-manipulation/manipulators/image.manipulator';
-import Http from 'src/server/http/http.util';
-import { CancellationToken } from 'src/server/submission/post/cancellation/cancellation-token';
-import {
-  FilePostData,
-  PostFile,
-} from 'src/server/submission/post/interfaces/file-post-data.interface';
-import { PostData } from 'src/server/submission/post/interfaces/post-data.interface';
-import { ValidationParts } from 'src/server/submission/validator/interfaces/validation-parts.interface';
 import FileSize from 'src/server/utils/filesize.util';
-import FormContent from 'src/server/utils/form-content.util';
-import WebsiteValidator from 'src/server/utils/website-validator.util';
-import { LoginResponse } from '../interfaces/login-response.interface';
-import { Website } from '../website.base';
 import _ from 'lodash';
-import WaitUtil from 'src/server/utils/wait.util';
-import { FileManagerService } from 'src/server/file-manager/file-manager.service';
+import { Megalodon } from '../megalodon/megalodon.service';
 
 const INFO_KEY = 'INSTANCE INFO';
 
@@ -49,49 +25,18 @@ type PixelfedInstanceInfo = {
 };
 
 @Injectable()
-export class Pixelfed extends Website {
-  constructor(private readonly fileRepository: FileManagerService) {
-    super();
-  }
-  readonly BASE_URL: string;
+export class Pixelfed extends Megalodon {
+
   readonly enableAdvertisement = false;
-  readonly acceptsAdditionalFiles = true;
-  readonly defaultDescriptionParser = PlaintextParser.parse;
   readonly acceptsFiles = ['png', 'jpeg', 'jpg', 'gif', 'swf', 'flv', 'mp4'];
 
-  async checkLoginStatus(data: UserAccountEntity): Promise<LoginResponse> {
-    const status: LoginResponse = { loggedIn: false, username: null };
-    const accountData: MegalodonAccountData = data.data;
-    if (accountData && accountData.token) {
-      const refresh = await this.refreshToken(accountData);
-      if (refresh) {
-        status.loggedIn = true;
-        status.username = accountData.username;
-        this.getInstanceInfo(data._id, accountData);
-      }
-    }
-    return status;
-  }
+  readonly megalodonService = 'mastodon'; // At some point will change this when they get Pixelfed support natively
 
-  private async getInstanceInfo(profileId: string, data: MegalodonAccountData) {
-    const client = generator('mastodon', data.website, data.token);
-    const instance = await client.getInstance();
+  getInstanceSettings(accountId: string) {
+    const instanceInfo: PixelfedInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
 
-    this.storeAccountInformation(profileId, INFO_KEY, instance.data);
-  }
-
-  // TBH not entirely sure why this is a thing, but its in the old code so... :shrug:
-  private async refreshToken(data: MegalodonAccountData): Promise<boolean> {
-    const M = this.getPixelfedInstance(data);
-    return true;
-  }
-
-  private getPixelfedInstance(data: MegalodonAccountData): Entity.Instance {
-    const client = generator('mastodon', data.website, data.token);
-    client.getInstance().then(res => {
-      return res.data;
-    });
-    return null;
+    this.maxCharLength = instanceInfo?.configuration?.statuses?.max_characters ?? 500;
+    this.maxMediaCount = instanceInfo ? instanceInfo?.configuration?.statuses?.max_media_attachments : 4;
   }
 
   getScalingOptions(file: FileRecord, accountId: string): ScalingOptions {
@@ -112,233 +57,8 @@ export class Pixelfed extends Website {
         };
   }
 
-  private async uploadMedia(
-    data: MegalodonAccountData,
-    file: PostFile,
-    altText: string,
-  ): Promise<{ id: string }> {
-    const upload = await Http.post<{ id: string; errors: any; url: string }>(
-      `${data.website}/api/v2/media`,
-      undefined,
-      {
-        type: 'multipart',
-        data: {
-          file,
-          description: altText,
-        },
-        requestOptions: { json: true },
-        headers: {
-          Accept: '*/*',
-          'User-Agent': 'node-mastodon-client/PostyBirb',
-          Authorization: `Bearer ${data.token}`,
-        },
-      },
-    );
-
-    this.verifyResponse(upload, 'Verify upload');
-
-    // Processing
-    if (upload.response.statusCode === 202 || !upload.body.url) {
-      for (let i = 0; i < 10; i++) {
-        await WaitUtil.wait(4000);
-        const checkUpload = await Http.get<{ id: string; errors: any; url: string }>(
-          `${data.website}/api/v1/media/${upload.body.id}`,
-          undefined,
-          {
-            requestOptions: { json: true },
-            headers: {
-              Accept: '*/*',
-              'User-Agent': 'node-mastodon-client/PostyBirb',
-              Authorization: `Bearer ${data.token}`,
-            },
-          },
-        );
-
-        if (checkUpload.body.url) {
-          break;
-        }
-      }
-    }
-
-    if (upload.body.errors) {
-      return Promise.reject(
-        this.createPostResponse({ additionalInfo: upload.body, message: upload.body.errors }),
-      );
-    }
-
-    return { id: upload.body.id };
-  }
-
-  async postFileSubmission(
-    cancellationToken: CancellationToken,
-    data: FilePostData<PixelfedFileOptions>,
-    accountData: MegalodonAccountData,
-  ): Promise<PostResponse> {
-    const M = generator('mastodon', accountData.website, accountData.token);
-
-    const files = [data.primary, ...data.additional];
-    this.checkCancelled(cancellationToken);
-    const uploadedMedias: {
-      id: string;
-    }[] = [];
-    for (const file of files) {
-      uploadedMedias.push(await this.uploadMedia(accountData, file.file, data.options.altText));
-    }
-
-    const instanceInfo: PixelfedInstanceInfo = this.getAccountInfo(data.part.accountId, INFO_KEY);
-    const chunkCount = instanceInfo
-      ? instanceInfo?.configuration?.statuses?.max_media_attachments
-      : 4;
-    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
-
-    const isSensitive = data.rating !== SubmissionRating.GENERAL;
-    const { options } = data;
-    const chunks = _.chunk(uploadedMedias, chunkCount);
-    let lastId = undefined;
-    let statusOptions: any = {
-      sensitive: isSensitive,
-      visibility: options.visibility || 'public',
-      in_reply_to_id: lastId,
-      spoiler_text: '',
-    };
-    let status = '';
-
-    for (let i = 0; i < chunks.length; i++) {
-      if (i === 0) {
-        status = `${options.useTitle && data.title ? `${data.title}\n` : ''}${
-          data.description
-        }`.substring(0, maxChars);
-        statusOptions.media_ids = chunks[i].map(media => media.id);
-      }
-
-      const tags = this.formatTags(data.tags);
-
-      this.logger.debug(`Number of tags set ${tags.length}`);
-
-      // Update the post content with the Tags if any are specified - for Pixelfed, we need to append
-      // these onto the post, *IF* there is character count available.
-      if (tags.length > 0) {
-        status += '\n\n';
-      }
-
-      tags.forEach(tag => {
-        let remain = maxChars - status.length;
-        let tagToInsert = tag;
-        if (remain > tagToInsert.length) {
-          status += ` ${tagToInsert}`;
-        }
-        // We don't exit the loop, so we can cram in every possible tag, even if there are short ones!
-      });
-
-      if (options.spoilerText) {
-        statusOptions.spoiler_text = options.spoilerText;
-      }
-
-      this.checkCancelled(cancellationToken);
-
-      await M.postStatus(status, statusOptions)
-        .then(result => {
-          lastId = result.data.id;
-          let res = result.data as Entity.Status;
-          return this.createPostResponse({ source: res.url });
-        })
-        .catch((err: Error) => {
-          return Promise.reject(this.createPostResponse({ message: err.message }));
-        });
-    }
-
-    return this.createPostResponse({});
-  }
-
-  formatTags(tags: string[]) {
-    return this.parseTags(
-      tags
-        .map(tag => tag.replace(/[^a-z0-9]/gi, ' '))
-        .map(tag =>
-          tag
-            .split(' ')
-            // .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(''),
-        ),
-      { spaceReplacer: '_' },
-    ).map(tag => `#${tag}`);
-  }
-
-  validateFileSubmission(
-    submission: FileSubmission,
-    submissionPart: SubmissionPart<PixelfedFileOptions>,
-    defaultPart: SubmissionPart<DefaultOptions>,
-  ): ValidationParts {
-    const problems: string[] = [];
-    const warnings: string[] = [];
-    const isAutoscaling: boolean = submissionPart.data.autoScale;
-
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    const instanceInfo: PixelfedInstanceInfo = this.getAccountInfo(
-      submissionPart.accountId,
-      INFO_KEY,
-    );
-    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
-
-    if (description.length > maxChars) {
-      warnings.push(
-        `Max description length allowed is ${maxChars} characters (for this Pixelfed client).`,
-      );
-    }
-
-    const files = [
-      submission.primary,
-      ...(submission.additional || []).filter(
-        f => !f.ignoredAccounts!.includes(submissionPart.accountId),
-      ),
-    ];
-
-    const maxImageSize = instanceInfo
-      ? instanceInfo?.configuration?.media_attachments?.image_size_limit
-      : FileSize.MBtoBytes(50);
-
-    files.forEach(file => {
-      const { type, size, name, mimetype } = file;
-      if (!WebsiteValidator.supportsFileType(file, this.acceptsFiles)) {
-        problems.push(`Does not support file format: (${name}) ${mimetype}.`);
-      }
-
-      if (maxImageSize < size) {
-        if (
-          isAutoscaling &&
-          type === FileSubmissionType.IMAGE &&
-          ImageManipulator.isMimeType(mimetype)
-        ) {
-          warnings.push(`${name} will be scaled down to ${FileSize.BytesToMB(maxImageSize)}MB`);
-        } else {
-          problems.push(`Pixelfed limits ${mimetype} to ${FileSize.BytesToMB(maxImageSize)}MB`);
-        }
-      }
-
-      // Check the image dimensions are not over 4000 x 4000 - this is the Pixelfed server max
-      if (
-        isAutoscaling &&
-        type === FileSubmissionType.IMAGE &&
-        (file.height > 4000 || file.width > 4000)
-      ) {
-        warnings.push(`${name} will be scaled down to a maximum size of 4000x4000, while maintaining
-           aspect ratio`);
-      }
-    });
-
-    if (
-      (submissionPart.data.tags.value.length > 1 || defaultPart.data.tags.value.length > 1) &&
-      submissionPart.data.visibility != 'public'
-    ) {
-      warnings.push(
-        `This post won't be listed under any hashtag as it is not public. Only public posts 
-              can be searched by hashtag.`,
-      );
-    }
-
-    return { problems, warnings };
+  // https://{instance}/i/web/post/{id}
+  getPostIdFromUrl(url: string): string | null {
+    return url.slice(url.lastIndexOf('/') + 1);
   }
 }

--- a/electron-app/src/server/websites/pleroma/pleroma.controller.ts
+++ b/electron-app/src/server/websites/pleroma/pleroma.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Query} from '@nestjs/common';
+
+@Controller('pleroma')
+export class PleromaController {
+
+  @Get('display/:auth')
+  async display(@Query('token') token : string, @Query('code') code : string) {
+    if (token === undefined) {
+      token = ""
+    }
+    if (code === undefined) {
+      code = ""
+    }
+
+    return `<html>
+    <p>Token: ${token} <br/>
+    Code: ${code} </p>
+    </html>`
+  }
+
+}

--- a/electron-app/src/server/websites/pleroma/pleroma.module.ts
+++ b/electron-app/src/server/websites/pleroma/pleroma.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { Pleroma } from './pleroma.service';
+import { FileManagerModule } from 'src/server/file-manager/file-manager.module';
+import { PleromaController } from './pleroma.controller';
+
+@Module({
+  controllers: [PleromaController],
+  providers: [Pleroma],
+  exports: [Pleroma],
+  imports: [FileManagerModule],
+})
+export class PleromaModule {}

--- a/electron-app/src/server/websites/pleroma/pleroma.service.ts
+++ b/electron-app/src/server/websites/pleroma/pleroma.service.ts
@@ -1,0 +1,463 @@
+import { Injectable } from '@nestjs/common';
+import generator, { Entity, Response } from 'megalodon'
+import {
+  DefaultOptions,
+  FileRecord,
+  FileSubmission,
+  FileSubmissionType,
+  PleromaAccountData,
+  PleromaFileOptions,
+  PleromaNotificationOptions,
+  PostResponse,
+  Submission,
+  SubmissionPart,
+  SubmissionRating,
+} from 'postybirb-commons';
+import { ScalingOptions } from '../interfaces/scaling-options.interface';
+import UserAccountEntity from 'src/server//account/models/user-account.entity';
+import { PlaintextParser } from 'src/server/description-parsing/plaintext/plaintext.parser';
+import ImageManipulator from 'src/server/file-manipulation/manipulators/image.manipulator';
+import { CancellationToken } from 'src/server/submission/post/cancellation/cancellation-token';
+import {
+  FilePostData,
+  PostFile,
+} from 'src/server/submission/post/interfaces/file-post-data.interface';
+import { PostData } from 'src/server/submission/post/interfaces/post-data.interface';
+import { ValidationParts } from 'src/server/submission/validator/interfaces/validation-parts.interface';
+import FileSize from 'src/server/utils/filesize.util';
+import FormContent from 'src/server/utils/form-content.util';
+import WebsiteValidator from 'src/server/utils/website-validator.util';
+import { LoginResponse } from '../interfaces/login-response.interface';
+import { Website } from '../website.base';
+import _ from 'lodash';
+import { FileManagerService } from 'src/server/file-manager/file-manager.service';
+import { Readable } from 'stream';
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+
+const INFO_KEY = 'INSTANCE INFO';
+
+type PleromaInstanceInfo = {
+  configuration: {
+    statuses: {
+      max_characters: number;
+      max_media_attachments: number;
+    };
+    media_attachments: {
+      supported_mime_types: string[];
+      image_size_limit: number;
+      video_size_limit: number;
+    };
+  };
+};
+
+@Injectable()
+export class Pleroma extends Website {
+  constructor(private readonly fileRepository: FileManagerService) {
+    super();
+  }
+  readonly BASE_URL: string;
+  readonly enableAdvertisement = false;
+  readonly acceptsAdditionalFiles = true;
+  readonly defaultDescriptionParser = PlaintextParser.parse;
+  readonly acceptsFiles = [
+    'png',
+    'jpeg',
+    'jpg',
+    'gif',
+    'swf',
+    'flv',
+    'mp4',
+    'doc',
+    'rtf',
+    'txt',
+    'mp3',
+  ];
+
+  async checkLoginStatus(data: UserAccountEntity): Promise<LoginResponse> {
+    const status: LoginResponse = { loggedIn: false, username: null };
+    const accountData: PleromaAccountData = data.data;
+    if (accountData && accountData.tokenData) {
+      const refresh = await this.refreshToken(accountData);
+      if (refresh) {
+        status.loggedIn = true;
+        status.username = accountData.username;
+        this.getInstanceInfo(data._id, accountData);
+      }
+    }
+    return status;
+  }
+
+  private async getInstanceInfo(profileId: string, data: PleromaAccountData) {   
+    const client = generator('pleroma', `https://${data.website}`, data.tokenData.access_token);
+    const instance = await client.getInstance();
+    this.storeAccountInformation(profileId, INFO_KEY, instance.data);
+  }
+
+  // TBH not entirely sure why this is a thing, but its in the old code so... :shrug:
+  private async refreshToken(data: PleromaAccountData): Promise<boolean> {
+    const M = this.getPleromaInstance(data);
+    return true;
+  }
+
+  private getPleromaInstance(data: PleromaAccountData) : Entity.Instance {
+    const client = generator('pleroma', `https://${data.website}`, data.tokenData.access_token);
+    client.getInstance().then((res) => {
+      return res.data;
+    });
+    return null;
+  }
+
+  getScalingOptions(file: FileRecord, accountId: string): ScalingOptions {
+    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
+    return instanceInfo?.configuration?.media_attachments
+      ? {
+          maxHeight: 4000,
+          maxWidth: 4000,
+          maxSize:
+            file.type === FileSubmissionType.IMAGE
+              ? instanceInfo.configuration.media_attachments.image_size_limit
+              : instanceInfo.configuration.media_attachments.video_size_limit,
+        }
+      : {           
+          maxHeight: 4000,
+          maxWidth: 4000,
+          maxSize: FileSize.MBtoBytes(16) 
+      };
+  }
+
+  private async uploadMedia(
+    data: PleromaAccountData,
+    file: PostFile,
+    altText: string,
+  ): Promise<{ id: string }> {
+    this.logger.log("Uploading media")
+    const M = generator('pleroma', `https://${data.website}`, data.tokenData.access_token);
+
+    // megalodon is odd, and doesnt seem to like the buffer being passed to the upload media call
+    // So lets write the file out to a temp file, then pass that to createReadStream, then that to uploadMedia.
+    // That works .... \o/
+
+    const tempDir = tmpdir();
+
+    fs.writeFileSync(path.join(tempDir, file.options.filename), file.value);
+
+    const upload = await M.uploadMedia(fs.createReadStream(path.join(tempDir, file.options.filename)), { description: altText });
+
+    this.logger.log(upload)
+
+    fs.unlink(path.join(tempDir, file.options.filename), (err) => { 
+      if (err) {
+        this.logger.error("Unable to remove the temp file", err.stack, err.message);
+      }
+    });
+
+    if (upload.status > 300) {
+      this.logger.log(upload);
+      return Promise.reject(
+        this.createPostResponse({ additionalInfo: upload.status, message: upload.statusText }),
+      );
+    }
+
+    this.logger.log("Pleroma image uploaded");
+
+    return { id: upload.data.id };
+  }
+
+  async postFileSubmission(
+    cancellationToken: CancellationToken,
+    data: FilePostData<PleromaFileOptions>,
+    accountData: PleromaAccountData,
+  ): Promise<PostResponse> {
+    const M = generator('pleroma', `https://${accountData.website}`, accountData.tokenData.access_token);
+
+    const files = [data.primary, ...data.additional];
+  
+    this.checkCancelled(cancellationToken);
+
+    const uploadedMedias: {
+      id: string;
+    }[] = [];
+    for (const file of files) {
+      uploadedMedias.push(await this.uploadMedia(accountData, file.file, data.options.altText));
+    }
+
+    this.logger.log("All Media uploaded!")
+
+    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(data.part.accountId, INFO_KEY);
+    const chunkCount = instanceInfo ? instanceInfo?.configuration?.statuses?.max_media_attachments : 4;
+    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
+
+    const isSensitive = data.rating !== SubmissionRating.GENERAL;
+    const { options } = data;
+    const chunks = _.chunk(uploadedMedias, chunkCount);
+    let lastId = undefined;
+    this.logger.log("Prepping post content")
+    for (let i = 0; i < chunks.length; i++) {
+      let statusOptions: any = {
+        status: '',
+        sensitive: isSensitive,
+        visibility: options.visibility || 'public',
+        spoiler_text: ''
+      };
+      let status = undefined;
+
+      if (i === 0) {
+        status = `${options.useTitle && data.title ? `${data.title}\n` : ''}${
+          data.description
+        }`.substring(0, maxChars)
+        this.logger.log(`Initial Status: ${status}`)
+
+        statusOptions = {
+          sensitive: isSensitive,
+          visibility: options.visibility || 'public',
+          media_ids: chunks[i].map((media) => media.id), 
+          spoiler_text: "",
+        }
+     } else {
+      statusOptions = {
+        sensitive: isSensitive,
+        visibility: options.visibility || 'public',
+        media_ids: chunks[i].map((media) => media.id),
+        in_reply_to_id: lastId,  
+        spoiler_text: "",    
+      }      
+     }
+
+     const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
+     if (replyToId) {
+       statusOptions.in_reply_to_id = replyToId;
+     }
+
+      const tags = this.formatTags(data.tags);
+
+      // Update the post content with the Tags if any are specified - for Pleroma, we need to append 
+      // these onto the post, *IF* there is character count available.
+      if (tags.length > 0) {
+        status += "\n\n";
+      }
+
+      tags.forEach(tag => {
+        let remain = maxChars - status.length;
+        let tagToInsert = tag;
+        if (remain > (tagToInsert.length)) {
+          status += ` ${tagToInsert}`
+        }
+        // We don't exit the loop, so we can cram in every possible tag, even if there are short ones!
+      })
+      
+      if (options.spoilerText) {
+        statusOptions.spoiler_text = options.spoilerText;
+      }
+
+      this.checkCancelled(cancellationToken);
+
+      await M.postStatus(status, statusOptions).then((result) => {
+        lastId = result.data.id;
+        let res = result.data as Entity.Status;
+        return this.createPostResponse({ source: res.url });
+      }).catch((err: Error) => {
+        return Promise.reject(
+          this.createPostResponse({ message: err.message }),
+        );
+      })
+    }
+
+    return this.createPostResponse({});
+  }
+
+  async postNotificationSubmission(
+    cancellationToken: CancellationToken,
+    data: PostData<Submission, PleromaNotificationOptions>,
+    accountData: PleromaAccountData,
+  ): Promise<PostResponse> {
+    const mInstance = this.getPleromaInstance(accountData);
+    const M = generator('pleroma', `https://${accountData.website}`, accountData.tokenData.access_token);
+    
+    const maxChars = mInstance ? mInstance?.configuration?.statuses?.max_characters : 500;
+
+    const isSensitive = data.rating !== SubmissionRating.GENERAL;
+
+    const { options } = data;
+    let status = `${options.useTitle && data.title ? `${data.title}\n` : ''}${data.description}`;
+    const statusOptions: any = {
+      sensitive: isSensitive,
+      visibility: options.visibility || 'public',
+      spoiler_text: ""
+    };
+
+    const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
+    if (replyToId) {
+      statusOptions.in_reply_to_id = replyToId;
+    }
+
+    const tags = this.formatTags(data.tags);
+
+    // Update the post content with the Tags if any are specified - for Pleroma, we need to append 
+    // these onto the post, *IF* there is character count available.
+    if (tags.length > 0) {
+      status += "\n\n";
+    }
+
+    tags.forEach(tag => {
+      let remain = maxChars - status.length;
+      let tagToInsert = tag;
+      if (remain > (tagToInsert.length)) {
+        status += ` ${tagToInsert}`
+      }
+      // We don't exit the loop, so we can cram in every possible tag, even if there are short ones!
+    })
+
+    if (options.spoilerText) {
+      statusOptions.spoiler_text = options.spoilerText;
+    }
+
+    this.checkCancelled(cancellationToken);
+
+    await M.postStatus(status, statusOptions).then((result) => {
+      let res = result.data as Entity.Status;
+      return this.createPostResponse({ source: res.url });
+    }).catch((err: Error) => {
+      return Promise.reject(
+        this.createPostResponse({ message: err.message }),
+      );
+    })
+    return this.createPostResponse({});
+  }
+
+  formatTags(tags: string[]) {
+    return this.parseTags(
+      tags
+        .map((tag) => tag.replace(/[^a-z0-9]/gi, ' '))
+        .map((tag) =>
+          tag
+            .split(' ')
+            // .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(''),
+        ),
+      { spaceReplacer: '_' },
+    ).map((tag) => `#${tag}`);
+  }
+
+  validateFileSubmission(
+    submission: FileSubmission,
+    submissionPart: SubmissionPart<PleromaFileOptions>,
+    defaultPart: SubmissionPart<DefaultOptions>,
+  ): ValidationParts {
+    this.logger.log(submission.primary.location)
+
+    const problems: string[] = [];
+    const warnings: string[] = [];
+    const isAutoscaling: boolean = submissionPart.data.autoScale;
+
+    const description = this.defaultDescriptionParser(
+      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
+    );
+
+    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(
+      submissionPart.accountId,
+      INFO_KEY,
+    );
+    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
+
+    if (description.length > maxChars) {
+      warnings.push(
+        `Max description length allowed is ${maxChars} characters (for this Pleroma client).`,
+      );
+    }
+
+    const files = [
+      submission.primary,
+      ...(submission.additional || []).filter(
+        (f) => !f.ignoredAccounts!.includes(submissionPart.accountId),
+      ),
+    ];
+
+    const maxImageSize = instanceInfo
+      ? instanceInfo?.configuration?.media_attachments?.image_size_limit
+      : FileSize.MBtoBytes(50);
+
+    files.forEach((file) => {
+      const { type, size, name, mimetype } = file;
+      if (!WebsiteValidator.supportsFileType(file, this.acceptsFiles)) {
+        problems.push(`Does not support file format: (${name}) ${mimetype}.`);
+      }
+
+      if (maxImageSize < size) {
+        if (
+          isAutoscaling &&
+          type === FileSubmissionType.IMAGE &&
+          ImageManipulator.isMimeType(mimetype)
+        ) {
+          warnings.push(`${name} will be scaled down to ${FileSize.BytesToMB(maxImageSize)}MB`);
+        } else {
+          problems.push(`Pleroma limits ${mimetype} to ${FileSize.BytesToMB(maxImageSize)}MB`);
+        }
+      }
+
+      // Check the image dimensions are not over 4000 x 4000 - this is the Pleroma server max
+      if (
+        isAutoscaling && 
+        type === FileSubmissionType.IMAGE && 
+        (file.height > 4000 || file.width > 4000)) {
+          warnings.push(`${name} will be scaled down to a maximum size of 4000x4000, while maintaining
+           aspect ratio`);
+        }
+    });
+
+    if ((submissionPart.data.tags.value.length > 1 || defaultPart.data.tags.value.length > 1) && 
+      submissionPart.data.visibility != "public") {
+        warnings.push(
+              `This post won't be listed under any hashtag as it is not public. Only public posts 
+              can be searched by hashtag.`,
+            );
+    }
+
+    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
+
+    return { problems, warnings };
+  }
+
+  validateNotificationSubmission(
+    submission: Submission,
+    submissionPart: SubmissionPart<PleromaNotificationOptions>,
+    defaultPart: SubmissionPart<DefaultOptions>,
+  ): ValidationParts {
+    const warnings = [];
+    const problems = [];
+    const description = this.defaultDescriptionParser(
+      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
+    );
+
+    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(
+      submissionPart.accountId,
+      INFO_KEY,
+    );
+    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
+    if (description.length > maxChars) {
+      warnings.push(
+        `Max description length allowed is ${maxChars} characters (for this Pleroma client).`,
+      );
+    }
+
+    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
+
+    return { problems, warnings };
+  }
+
+  private validateReplyToUrl(problems: string[], url?: string): void {
+    if(url?.trim() && !this.getPostIdFromUrl(url)) {
+      problems.push("Invalid post URL to reply to.");
+    }
+  }
+
+  private getPostIdFromUrl(url: string): string | null {
+    if (url) {
+      const match = url.slice(url.lastIndexOf('/')+1)
+      return match ? match[1] : null;
+    } else {
+      return null;
+    }
+  }
+}

--- a/electron-app/src/server/websites/pleroma/pleroma.service.ts
+++ b/electron-app/src/server/websites/pleroma/pleroma.service.ts
@@ -127,7 +127,7 @@ export class Pleroma extends Website {
       };
   }
 
-  private async uploadMedia(
+  public async uploadMedia(
     data: MegalodonAccountData,
     file: PostFile,
     altText: string,

--- a/electron-app/src/server/websites/pleroma/pleroma.service.ts
+++ b/electron-app/src/server/websites/pleroma/pleroma.service.ts
@@ -1,40 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import generator, { Entity, Response } from 'megalodon'
 import {
-  DefaultOptions,
   FileRecord,
-  FileSubmission,
   FileSubmissionType,
-  MegalodonAccountData,
-  PleromaFileOptions,
-  PleromaNotificationOptions,
-  PostResponse,
-  Submission,
-  SubmissionPart,
-  SubmissionRating,
 } from 'postybirb-commons';
 import { ScalingOptions } from '../interfaces/scaling-options.interface';
-import UserAccountEntity from 'src/server//account/models/user-account.entity';
-import { PlaintextParser } from 'src/server/description-parsing/plaintext/plaintext.parser';
-import ImageManipulator from 'src/server/file-manipulation/manipulators/image.manipulator';
-import { CancellationToken } from 'src/server/submission/post/cancellation/cancellation-token';
-import {
-  FilePostData,
-  PostFile,
-} from 'src/server/submission/post/interfaces/file-post-data.interface';
-import { PostData } from 'src/server/submission/post/interfaces/post-data.interface';
-import { ValidationParts } from 'src/server/submission/validator/interfaces/validation-parts.interface';
 import FileSize from 'src/server/utils/filesize.util';
-import FormContent from 'src/server/utils/form-content.util';
-import WebsiteValidator from 'src/server/utils/website-validator.util';
-import { LoginResponse } from '../interfaces/login-response.interface';
-import { Website } from '../website.base';
 import _ from 'lodash';
-import { FileManagerService } from 'src/server/file-manager/file-manager.service';
-import { Readable } from 'stream';
-import * as fs from 'fs';
-import { tmpdir } from 'os';
-import * as path from 'path';
 import { Megalodon } from '../megalodon/megalodon.service';
 
 const INFO_KEY = 'INSTANCE INFO';
@@ -71,6 +42,7 @@ export class Pleroma extends Megalodon {
   ];
 
   getInstanceSettings(accountId: string) {
+    console.log(this.getAccountInfo(accountId, INFO_KEY));
     const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
 
     this.maxCharLength = instanceInfo?.max_toot_chars ?? 500;

--- a/electron-app/src/server/websites/pleroma/pleroma.service.ts
+++ b/electron-app/src/server/websites/pleroma/pleroma.service.ts
@@ -35,32 +35,27 @@ import { Readable } from 'stream';
 import * as fs from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
+import { Megalodon } from '../megalodon/megalodon.service';
 
 const INFO_KEY = 'INSTANCE INFO';
 
 type PleromaInstanceInfo = {
+  upload_limit?: number; // Pleroma, Akkoma
+  max_toot_chars?: number; // Pleroma, Akkoma
+  max_media_attachments?: number; //Pleroma
   configuration: {
-    statuses: {
-      max_characters: number;
-      max_media_attachments: number;
-    };
     media_attachments: {
-      supported_mime_types: string[];
       image_size_limit: number;
       video_size_limit: number;
-    };
-  };
+    };  
+  }
 };
 
 @Injectable()
-export class Pleroma extends Website {
-  constructor(private readonly fileRepository: FileManagerService) {
-    super();
-  }
-  readonly BASE_URL: string;
-  readonly enableAdvertisement = false;
+export class Pleroma extends Megalodon {
+
   readonly acceptsAdditionalFiles = true;
-  readonly defaultDescriptionParser = PlaintextParser.parse;
+  megalodonService: 'mastodon' | 'pleroma' | 'misskey' | 'friendica' = 'pleroma';
   readonly acceptsFiles = [
     'png',
     'jpeg',
@@ -75,38 +70,11 @@ export class Pleroma extends Website {
     'mp3',
   ];
 
-  async checkLoginStatus(data: UserAccountEntity): Promise<LoginResponse> {
-    const status: LoginResponse = { loggedIn: false, username: null };
-    const accountData: MegalodonAccountData = data.data;
-    if (accountData && accountData.token) {
-      const refresh = await this.refreshToken(accountData);
-      if (refresh) {
-        status.loggedIn = true;
-        status.username = accountData.username;
-        this.getInstanceInfo(data._id, accountData);
-      }
-    }
-    return status;
-  }
+  getInstanceSettings(accountId: string) {
+    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(accountId, INFO_KEY);
 
-  private async getInstanceInfo(profileId: string, data: MegalodonAccountData) {   
-    const client = generator('pleroma', `https://${data.website}`, data.token); // token => tokenData.access_token
-    const instance = await client.getInstance();
-    this.storeAccountInformation(profileId, INFO_KEY, instance.data);
-  }
-
-  // TBH not entirely sure why this is a thing, but its in the old code so... :shrug:
-  private async refreshToken(data: MegalodonAccountData): Promise<boolean> {
-    const M = this.getPleromaInstance(data);
-    return true;
-  }
-
-  private getPleromaInstance(data: MegalodonAccountData) : Entity.Instance {
-    const client = generator('pleroma', `https://${data.website}`, data.token);
-    client.getInstance().then((res) => {
-      return res.data;
-    });
-    return null;
+    this.maxCharLength = instanceInfo?.max_toot_chars ?? 500;
+    this.maxMediaCount = instanceInfo?.max_media_attachments ?? 4;
   }
 
   getScalingOptions(file: FileRecord, accountId: string): ScalingOptions {
@@ -127,332 +95,7 @@ export class Pleroma extends Website {
       };
   }
 
-  public async uploadMedia(
-    data: MegalodonAccountData,
-    file: PostFile,
-    altText: string,
-  ): Promise<{ id: string }> {
-    this.logger.log("Uploading media")
-    const M = generator('pleroma', `https://${data.website}`, data.token);
-
-    // megalodon is odd, and doesnt seem to like the buffer being passed to the upload media call
-    // So lets write the file out to a temp file, then pass that to createReadStream, then that to uploadMedia.
-    // That works .... \o/
-
-    const tempDir = tmpdir();
-
-    fs.writeFileSync(path.join(tempDir, file.options.filename), file.value);
-
-    const upload = await M.uploadMedia(fs.createReadStream(path.join(tempDir, file.options.filename)), { description: altText });
-
-    this.logger.log(upload)
-
-    fs.unlink(path.join(tempDir, file.options.filename), (err) => { 
-      if (err) {
-        this.logger.error("Unable to remove the temp file", err.stack, err.message);
-      }
-    });
-
-    if (upload.status > 300) {
-      this.logger.log(upload);
-      return Promise.reject(
-        this.createPostResponse({ additionalInfo: upload.status, message: upload.statusText }),
-      );
-    }
-
-    this.logger.log("Pleroma image uploaded");
-
-    return { id: upload.data.id };
-  }
-
-  async postFileSubmission(
-    cancellationToken: CancellationToken,
-    data: FilePostData<PleromaFileOptions>,
-    accountData: MegalodonAccountData,
-  ): Promise<PostResponse> {
-    const M = generator('pleroma', `https://${accountData.website}`, accountData.token);
-
-    const files = [data.primary, ...data.additional];
-  
-    this.checkCancelled(cancellationToken);
-
-    const uploadedMedias: {
-      id: string;
-    }[] = [];
-    for (const file of files) {
-      uploadedMedias.push(await this.uploadMedia(accountData, file.file, data.options.altText));
-    }
-
-    this.logger.log("All Media uploaded!")
-
-    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(data.part.accountId, INFO_KEY);
-    const chunkCount = instanceInfo ? instanceInfo?.configuration?.statuses?.max_media_attachments : 4;
-    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
-
-    const isSensitive = data.rating !== SubmissionRating.GENERAL;
-    const { options } = data;
-    const chunks = _.chunk(uploadedMedias, chunkCount);
-    let lastId = undefined;
-    this.logger.log("Prepping post content")
-    for (let i = 0; i < chunks.length; i++) {
-      let statusOptions: any = {
-        status: '',
-        sensitive: isSensitive,
-        visibility: options.visibility || 'public',
-        spoiler_text: ''
-      };
-      let status = undefined;
-
-      if (i === 0) {
-        status = `${options.useTitle && data.title ? `${data.title}\n` : ''}${
-          data.description
-        }`.substring(0, maxChars)
-        this.logger.log(`Initial Status: ${status}`)
-
-        statusOptions = {
-          sensitive: isSensitive,
-          visibility: options.visibility || 'public',
-          media_ids: chunks[i].map((media) => media.id), 
-          spoiler_text: "",
-        }
-     } else {
-      statusOptions = {
-        sensitive: isSensitive,
-        visibility: options.visibility || 'public',
-        media_ids: chunks[i].map((media) => media.id),
-        in_reply_to_id: lastId,  
-        spoiler_text: "",    
-      }      
-     }
-
-     const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
-     if (replyToId) {
-       statusOptions.in_reply_to_id = replyToId;
-     }
-
-      const tags = this.formatTags(data.tags);
-
-      // Update the post content with the Tags if any are specified - for Pleroma, we need to append 
-      // these onto the post, *IF* there is character count available.
-      if (tags.length > 0) {
-        status += "\n\n";
-      }
-
-      tags.forEach(tag => {
-        let remain = maxChars - status.length;
-        let tagToInsert = tag;
-        if (remain > (tagToInsert.length)) {
-          status += ` ${tagToInsert}`
-        }
-        // We don't exit the loop, so we can cram in every possible tag, even if there are short ones!
-      })
-      
-      if (options.spoilerText) {
-        statusOptions.spoiler_text = options.spoilerText;
-      }
-
-      this.checkCancelled(cancellationToken);
-
-      await M.postStatus(status, statusOptions).then((result) => {
-        lastId = result.data.id;
-        let res = result.data as Entity.Status;
-        return this.createPostResponse({ source: res.url });
-      }).catch((err: Error) => {
-        return Promise.reject(
-          this.createPostResponse({ message: err.message }),
-        );
-      })
-    }
-
-    return this.createPostResponse({});
-  }
-
-  async postNotificationSubmission(
-    cancellationToken: CancellationToken,
-    data: PostData<Submission, PleromaNotificationOptions>,
-    accountData: MegalodonAccountData,
-  ): Promise<PostResponse> {
-    const mInstance = this.getPleromaInstance(accountData);
-    const M = generator('pleroma', `https://${accountData.website}`, accountData.token);
-    
-    const maxChars = mInstance ? mInstance?.configuration?.statuses?.max_characters : 500;
-
-    const isSensitive = data.rating !== SubmissionRating.GENERAL;
-
-    const { options } = data;
-    let status = `${options.useTitle && data.title ? `${data.title}\n` : ''}${data.description}`;
-    const statusOptions: any = {
-      sensitive: isSensitive,
-      visibility: options.visibility || 'public',
-      spoiler_text: ""
-    };
-
-    const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
-    if (replyToId) {
-      statusOptions.in_reply_to_id = replyToId;
-    }
-
-    const tags = this.formatTags(data.tags);
-
-    // Update the post content with the Tags if any are specified - for Pleroma, we need to append 
-    // these onto the post, *IF* there is character count available.
-    if (tags.length > 0) {
-      status += "\n\n";
-    }
-
-    tags.forEach(tag => {
-      let remain = maxChars - status.length;
-      let tagToInsert = tag;
-      if (remain > (tagToInsert.length)) {
-        status += ` ${tagToInsert}`
-      }
-      // We don't exit the loop, so we can cram in every possible tag, even if there are short ones!
-    })
-
-    if (options.spoilerText) {
-      statusOptions.spoiler_text = options.spoilerText;
-    }
-
-    this.checkCancelled(cancellationToken);
-
-    await M.postStatus(status, statusOptions).then((result) => {
-      let res = result.data as Entity.Status;
-      return this.createPostResponse({ source: res.url });
-    }).catch((err: Error) => {
-      return Promise.reject(
-        this.createPostResponse({ message: err.message }),
-      );
-    })
-    return this.createPostResponse({});
-  }
-
-  formatTags(tags: string[]) {
-    return this.parseTags(
-      tags
-        .map((tag) => tag.replace(/[^a-z0-9]/gi, ' '))
-        .map((tag) =>
-          tag
-            .split(' ')
-            // .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(''),
-        ),
-      { spaceReplacer: '_' },
-    ).map((tag) => `#${tag}`);
-  }
-
-  validateFileSubmission(
-    submission: FileSubmission,
-    submissionPart: SubmissionPart<PleromaFileOptions>,
-    defaultPart: SubmissionPart<DefaultOptions>,
-  ): ValidationParts {
-    this.logger.log(submission.primary.location)
-
-    const problems: string[] = [];
-    const warnings: string[] = [];
-    const isAutoscaling: boolean = submissionPart.data.autoScale;
-
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(
-      submissionPart.accountId,
-      INFO_KEY,
-    );
-    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
-
-    if (description.length > maxChars) {
-      warnings.push(
-        `Max description length allowed is ${maxChars} characters (for this Pleroma client).`,
-      );
-    }
-
-    const files = [
-      submission.primary,
-      ...(submission.additional || []).filter(
-        (f) => !f.ignoredAccounts!.includes(submissionPart.accountId),
-      ),
-    ];
-
-    const maxImageSize = instanceInfo
-      ? instanceInfo?.configuration?.media_attachments?.image_size_limit
-      : FileSize.MBtoBytes(50);
-
-    files.forEach((file) => {
-      const { type, size, name, mimetype } = file;
-      if (!WebsiteValidator.supportsFileType(file, this.acceptsFiles)) {
-        problems.push(`Does not support file format: (${name}) ${mimetype}.`);
-      }
-
-      if (maxImageSize < size) {
-        if (
-          isAutoscaling &&
-          type === FileSubmissionType.IMAGE &&
-          ImageManipulator.isMimeType(mimetype)
-        ) {
-          warnings.push(`${name} will be scaled down to ${FileSize.BytesToMB(maxImageSize)}MB`);
-        } else {
-          problems.push(`Pleroma limits ${mimetype} to ${FileSize.BytesToMB(maxImageSize)}MB`);
-        }
-      }
-
-      // Check the image dimensions are not over 4000 x 4000 - this is the Pleroma server max
-      if (
-        isAutoscaling && 
-        type === FileSubmissionType.IMAGE && 
-        (file.height > 4000 || file.width > 4000)) {
-          warnings.push(`${name} will be scaled down to a maximum size of 4000x4000, while maintaining
-           aspect ratio`);
-        }
-    });
-
-    if ((submissionPart.data.tags.value.length > 1 || defaultPart.data.tags.value.length > 1) && 
-      submissionPart.data.visibility != "public") {
-        warnings.push(
-              `This post won't be listed under any hashtag as it is not public. Only public posts 
-              can be searched by hashtag.`,
-            );
-    }
-
-    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
-
-    return { problems, warnings };
-  }
-
-  validateNotificationSubmission(
-    submission: Submission,
-    submissionPart: SubmissionPart<PleromaNotificationOptions>,
-    defaultPart: SubmissionPart<DefaultOptions>,
-  ): ValidationParts {
-    const warnings = [];
-    const problems = [];
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    const instanceInfo: PleromaInstanceInfo = this.getAccountInfo(
-      submissionPart.accountId,
-      INFO_KEY,
-    );
-    const maxChars = instanceInfo ? instanceInfo?.configuration?.statuses?.max_characters : 500;
-    if (description.length > maxChars) {
-      warnings.push(
-        `Max description length allowed is ${maxChars} characters (for this Pleroma client).`,
-      );
-    }
-
-    this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
-
-    return { problems, warnings };
-  }
-
-  private validateReplyToUrl(problems: string[], url?: string): void {
-    if(url?.trim() && !this.getPostIdFromUrl(url)) {
-      problems.push("Invalid post URL to reply to.");
-    }
-  }
-
-  private getPostIdFromUrl(url: string): string | null {
+  getPostIdFromUrl(url: string): string | null {
     if (url) {
       const match = url.slice(url.lastIndexOf('/')+1)
       return match ? match[1] : null;

--- a/electron-app/src/server/websites/website-provider.service.ts
+++ b/electron-app/src/server/websites/website-provider.service.ts
@@ -32,6 +32,7 @@ import { SubscribeStarAdult } from './subscribe-star-adult/subscribe-star-adult.
 import { Pixelfed } from './pixelfed/pixelfed.service';
 import { MissKey } from './misskey/misskey.service';
 import { Bluesky } from './bluesky/bluesky.service';
+import { Pleroma } from './pleroma/pleroma.service';
 
 @Injectable()
 export class WebsiteProvider {
@@ -71,6 +72,7 @@ export class WebsiteProvider {
     readonly itaku: Itaku,
     readonly picarto: Picarto,
     readonly pixelfed: Pixelfed,
+    readonly pleroma: Pleroma,
   ) {
     // eslint-disable-next-line
     this.websiteModules = [...arguments].filter(arg => arg instanceof Website);

--- a/electron-app/src/server/websites/websites.module.ts
+++ b/electron-app/src/server/websites/websites.module.ts
@@ -26,6 +26,7 @@ import { DeviantArtModule } from './deviant-art/deviant-art.module';
 import { ManebooruModule } from './manebooru/manebooru.module';
 import { MastodonModule } from './mastodon/mastodon.module';
 import { MissKeyModule } from './misskey/misskey.module';
+import { PleromaModule } from './pleroma/pleroma.module';
 import { PillowfortModule } from './pillowfort/pillowfort.module';
 import { TelegramModule } from './telegram/telegram.module';
 import { FurbooruModule } from './furbooru/furbooru.module';
@@ -58,6 +59,7 @@ import { BlueskyModule } from './bluesky/bluesky.module';
     ManebooruModule,
     MastodonModule,
     MissKeyModule,
+    PleromaModule,
     NewgroundsModule,
     PatreonModule,
     PiczelModule,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postybirb-plus",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "postybirb-plus",
-      "version": "3.1.30",
+      "version": "3.1.31",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -19,7 +19,7 @@
         "axios": "^0.21.4",
         "file-saver": "^2.0.5",
         "lodash": "^4.17.21",
-        "megalodon": "^6.2.0",
+        "megalodon": "^7.0.0",
         "mobx": "^5.15.7",
         "mobx-react": "^6.3.1",
         "postybirb-commons": "file:../commons",
@@ -52,7 +52,7 @@
         "@types/node": "^14.11.1",
         "class-transformer": "^0.3.1",
         "class-validator": "^0.12.2",
-        "megalodon": "^6.2.0"
+        "megalodon": "^7.0.0"
       }
     },
     "../commons/node_modules/@types/node": {
@@ -12459,32 +12459,32 @@
       }
     },
     "node_modules/megalodon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-6.2.0.tgz",
-      "integrity": "sha512-OTnZ8zcg9fhYMTbGDTDEOunSA0/zIqzEu03Ne925aTaAqL7i4gnxiwBHrRusPcA7JS4wnuicAYuwuOXZVrDK0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/megalodon/-/megalodon-7.0.1.tgz",
+      "integrity": "sha512-zJhYXw+FNaNkjpY8uJo+C4u6p2yxdPYRmnY4tMY1/kQQca9ZdqvP9a9sT4Yiv7uvQPxwXLjVeWNqWQefkBwT1A==",
       "dependencies": {
-        "@types/oauth": "^0.9.0",
+        "@types/oauth": "^0.9.2",
         "@types/ws": "^8.5.5",
-        "axios": "1.4.0",
+        "axios": "1.5.0",
         "dayjs": "^1.11.9",
         "form-data": "^4.0.0",
-        "https-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.2",
         "oauth": "^0.10.0",
         "object-assign-deep": "^0.4.0",
         "parse-link-header": "^2.0.0",
-        "socks-proxy-agent": "^8.0.1",
+        "socks-proxy-agent": "^8.0.2",
         "typescript": "5.1.6",
-        "uuid": "^9.0.0",
-        "ws": "8.13.0"
+        "uuid": "^9.0.1",
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=15.0.0"
       }
     },
     "node_modules/megalodon/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -12529,9 +12529,9 @@
       }
     },
     "node_modules/megalodon/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postybirb-plus-ui",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "postybirb-plus-ui",
-      "version": "3.1.30",
+      "version": "3.1.31",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@atproto/api": "^0.6.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.21.4",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.21",
-    "megalodon": "^6.2.0",
+    "megalodon": "^7.0.0",
     "mobx": "^5.15.7",
     "mobx-react": "^6.3.1",
     "postybirb-commons": "file:../commons",

--- a/ui/src/websites/mastodon/MastodonLogin.tsx
+++ b/ui/src/websites/mastodon/MastodonLogin.tsx
@@ -2,11 +2,11 @@ import { Button, Form, Input, message, Spin } from 'antd';
 import Axios from 'axios';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { MastodonAccountData } from 'postybirb-commons';
+import { MegalodonAccountData } from 'postybirb-commons';
 import LoginService from '../../services/login.service';
 import { LoginDialogProps } from '../interfaces/website.interface';
 
-interface State extends MastodonAccountData {
+interface State extends MegalodonAccountData {
   code: string;
   loading: boolean;
 }

--- a/ui/src/websites/pixelfed/PixelfedLogin.tsx
+++ b/ui/src/websites/pixelfed/PixelfedLogin.tsx
@@ -2,12 +2,12 @@ import { Button, Form, Input, message, Spin } from 'antd';
 import Axios from 'axios';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { PixelfedAccountData } from 'postybirb-commons';
+import { MegalodonAccountData } from 'postybirb-commons';
 import LoginService from '../../services/login.service';
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { stringify } from 'querystring';
 
-interface State extends PixelfedAccountData {
+interface State extends MegalodonAccountData {
   code: string;
   loading: boolean;
 }

--- a/ui/src/websites/pleroma/Pleroma.tsx
+++ b/ui/src/websites/pleroma/Pleroma.tsx
@@ -1,0 +1,144 @@
+import { Checkbox, Form, Input, Select } from 'antd';
+import {
+  FileSubmission,
+  PleromaFileOptions,
+  PleromaNotificationOptions,
+  Submission,
+  SubmissionRating
+} from 'postybirb-commons';
+import React from 'react';
+import { WebsiteSectionProps } from '../form-sections/website-form-section.interface';
+import GenericFileSubmissionSection from '../generic/GenericFileSubmissionSection';
+import { GenericSelectProps } from '../generic/GenericSelectProps';
+import GenericSubmissionSection from '../generic/GenericSubmissionSection';
+import { LoginDialogProps } from '../interfaces/website.interface';
+import { WebsiteImpl } from '../website.base';
+import PleromaLogin from './PleromaLogin';
+
+export class Pleroma extends WebsiteImpl {
+  internalName: string = 'Pleroma';
+  name: string = 'Pleroma Instance';
+  supportsAdditionalFiles: boolean = true;
+  supportsTags: boolean = true;
+  loginUrl: string = '';
+
+  LoginDialog = (props: LoginDialogProps) => <PleromaLogin {...props} />;
+
+  FileSubmissionForm = (props: WebsiteSectionProps<FileSubmission, PleromaFileOptions>) => (
+    <PleromaFileSubmissionForm
+      key={props.part.accountId}
+      {...props}
+      ratingOptions={{
+        show: true,
+        ratings: [
+          { name: 'Safe', value: SubmissionRating.GENERAL },
+          { name: 'Sensitive', value: SubmissionRating.ADULT }
+        ]
+      }}
+      tagOptions={{ show: true }}
+      hideThumbnailOptions={true}
+    />
+  );
+
+  NotificationSubmissionForm = (
+    props: WebsiteSectionProps<Submission, PleromaNotificationOptions>
+  ) => (
+    <PleromaNotificationSubmissionForm
+      key={props.part.accountId}
+      {...props}
+      ratingOptions={{
+        show: true,
+        ratings: [
+          { name: 'Safe', value: SubmissionRating.GENERAL },
+          { name: 'Sensitive', value: SubmissionRating.ADULT }
+        ]
+      }}
+      tagOptions={{ show: true }}
+    />
+  );
+}
+
+class PleromaNotificationSubmissionForm extends GenericSubmissionSection<
+  PleromaNotificationOptions> {
+  renderLeftForm(data: PleromaNotificationOptions) {
+    const elements = super.renderLeftForm(data);
+    elements.push(
+      <div>
+        <Checkbox
+          checked={data.useTitle}
+          onChange={this.handleCheckedChange.bind(this, 'useTitle')}
+        >
+          Use title
+        </Checkbox>
+      </div>,
+      <Form.Item label="Spoiler Text">
+        <Input
+          value={data.spoilerText}
+          onChange={this.handleValueChange.bind(this, 'spoilerText')}
+        />
+      </Form.Item>,
+      <Form.Item label="Post Visibility">
+        <Select
+          {...GenericSelectProps}
+          className="w-full"
+          value={data.visibility}
+          onSelect={this.setValue.bind(this, 'visibility')}
+        >
+          <Select.Option value="public">Public</Select.Option>
+          <Select.Option value="unlisted">Unlisted</Select.Option>
+          <Select.Option value="private">Followers Only</Select.Option>
+          <Select.Option value="direct">Mentioned Users Only</Select.Option>
+        </Select>
+      </Form.Item>,
+      <Form.Item label="Reply To Post URL">
+        <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+      </Form.Item>,
+    );
+    return elements;
+  }
+}
+
+export class PleromaFileSubmissionForm extends GenericFileSubmissionSection<PleromaFileOptions> {
+  renderLeftForm(data: PleromaFileOptions) {
+    const elements = super.renderLeftForm(data);
+    elements.push(
+      <div>
+        <Checkbox
+          checked={data.useTitle}
+          onChange={this.handleCheckedChange.bind(this, 'useTitle')}
+        >
+          Use title
+        </Checkbox>
+      </div>,
+      <Form.Item label="Spoiler Text">
+        <Input
+          value={data.spoilerText}
+          onChange={this.handleValueChange.bind(this, 'spoilerText')}
+        />
+      </Form.Item>,
+      <Form.Item label="Alt Text">
+        <Input
+          value={data.altText}
+          onChange={this.handleValueChange.bind(this, 'altText')}
+        />
+      </Form.Item>,
+      <Form.Item label="Post Visibility">
+        <Select
+          {...GenericSelectProps}
+          className="w-full"
+          value={data.visibility}
+          onSelect={this.setValue.bind(this, 'visibility')}
+        >
+          <Select.Option value="public">Public</Select.Option>
+          <Select.Option value="unlisted">Unlisted</Select.Option>
+          <Select.Option value="private">Followers Only</Select.Option>
+          <Select.Option value="direct">Mentioned Users Only</Select.Option>
+        </Select>
+      </Form.Item>,
+      <Form.Item label="Reply To Post URL">
+        <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+      </Form.Item>,
+    );
+    return elements;
+  }
+}

--- a/ui/src/websites/pleroma/PleromaLogin.tsx
+++ b/ui/src/websites/pleroma/PleromaLogin.tsx
@@ -1,11 +1,9 @@
 import { Button, Form, Input, message, Spin } from 'antd';
-import Axios from 'axios';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { MegalodonAccountData } from 'postybirb-commons';
 import LoginService from '../../services/login.service';
 import { LoginDialogProps } from '../interfaces/website.interface';
-
 import generator, { OAuth } from 'megalodon'
 
 interface State extends MegalodonAccountData {
@@ -22,8 +20,8 @@ export default class PleromaLogin extends React.Component<LoginDialogProps, Stat
     loading: true,
     client_id: '',
     client_secret: '',
-    tokenData: null,
-    username: ''
+    username: '',
+    token: ''
   };
 
   private view: any;

--- a/ui/src/websites/pleroma/PleromaLogin.tsx
+++ b/ui/src/websites/pleroma/PleromaLogin.tsx
@@ -1,0 +1,131 @@
+import { Button, Form, Input, message, Spin } from 'antd';
+import Axios from 'axios';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { PleromaAccountData } from 'postybirb-commons';
+import LoginService from '../../services/login.service';
+import { LoginDialogProps } from '../interfaces/website.interface';
+
+import generator, { OAuth } from 'megalodon'
+
+interface State extends PleromaAccountData {
+  code: string;
+  client_id: string;
+  client_secret: string;
+  loading: boolean;
+}
+
+export default class PleromaLogin extends React.Component<LoginDialogProps, State> {
+  state: State = {
+    website: 'pleroma.io',
+    code: '',
+    loading: true,
+    client_id: '',
+    client_secret: '',
+    tokenData: null,
+    username: ''
+  };
+
+  private view: any;
+
+  constructor(props: LoginDialogProps) {
+    super(props);
+    this.state = {
+      ...this.state,
+      ...(props.data as State)
+    };
+  }
+
+  componentDidMount() {
+    const node = ReactDOM.findDOMNode(this);
+    if (node instanceof HTMLElement) {
+      const view: any = node.querySelector('.webview');
+      this.view = view;
+      view.addEventListener('did-stop-loading', () => {
+        if (this.state.loading) this.setState({ loading: false });
+      });
+      view.allowpopups = true;
+      view.partition = `persist:${this.props.account._id}`;
+      this.getAuthURL(this.state.website);
+    }
+  }
+
+  private getAuthURL(website: string) {
+    let auth_url : string = "";
+
+    // Get the Auth URL ... Display it. 
+    const client = generator('pleroma', `https://${website}`);
+    let opts: any = {
+      redirect_uris: `https://localhost:${window['PORT']}/misskey/display/${window.AUTH_ID}`
+    }
+    client.registerApp('PostyBirb', opts )
+      .then(appData => {
+        this.state.client_id = appData.clientId;
+        this.state.client_secret = appData.clientSecret;
+        this.state.username = appData.name;
+        auth_url = appData.url || "Error - no auth url";
+        this.view.src = auth_url;
+      });
+  }
+
+  submit() {
+    const client = generator('pleroma', `https://${this.state.website}`);
+    client.fetchAccessToken(this.state.client_id, this.state.client_secret, this.state.code).then((value: OAuth.TokenData) => {
+      // Get the username so we have complete data.
+      const usernameClient = generator('pleroma', `https://${this.state.website}`, value.accessToken);
+      usernameClient.verifyAccountCredentials().then((res)=>{
+        let website = `https://${this.state.website}`;
+        this.state.username = res.data.username;
+        this.state.tokenData = value;
+        LoginService.setAccountData(this.props.account._id, this.state ).then(
+          () => {
+            message.success(`${this.state.website} authenticated.`);
+          });
+      });
+    })
+    .catch((err: Error) => {
+      message.error(`Failed to authenticate ${this.state.website}.`);
+    })
+  }
+
+  isValid(): boolean {
+    return !!this.state.website && !!this.state.code;
+  }
+
+  render() {
+    return (
+      <div className="h-full">
+        <div className="container">
+          <Form layout="vertical">
+            <Form.Item label="Website" required>
+              <Input
+                className="w-full"
+                defaultValue={this.state.website}
+                addonBefore="https://"
+                onBlur={({ target }) => {
+                  const website = target.value.replace(/(https:\/\/|http:\/\/)/, '');
+                  this.view.loadURL(this.getAuthURL(website));
+                  this.setState({ website });
+                }}
+              />
+            </Form.Item>
+            <Form.Item label="Code" help="Obtained from authenticating the website" required>
+              <Input
+                value={this.state.code}
+                onChange={({ target }) => this.setState({ code: target.value })}
+                addonAfter={
+                  <Button onClick={this.submit.bind(this)} disabled={!this.isValid()}>
+                    Authorize
+                  </Button>
+                }
+              />
+            </Form.Item>
+          </Form>
+        </div>
+        <Spin wrapperClassName="full-size-spinner" spinning={this.state.loading}>
+          <webview className="webview h-full w-full" />
+        </Spin>
+      </div>
+    );
+  }
+}

--- a/ui/src/websites/pleroma/PleromaLogin.tsx
+++ b/ui/src/websites/pleroma/PleromaLogin.tsx
@@ -2,13 +2,13 @@ import { Button, Form, Input, message, Spin } from 'antd';
 import Axios from 'axios';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { PleromaAccountData } from 'postybirb-commons';
+import { MegalodonAccountData } from 'postybirb-commons';
 import LoginService from '../../services/login.service';
 import { LoginDialogProps } from '../interfaces/website.interface';
 
 import generator, { OAuth } from 'megalodon'
 
-interface State extends PleromaAccountData {
+interface State extends MegalodonAccountData {
   code: string;
   client_id: string;
   client_secret: string;
@@ -76,7 +76,7 @@ export default class PleromaLogin extends React.Component<LoginDialogProps, Stat
       usernameClient.verifyAccountCredentials().then((res)=>{
         let website = `https://${this.state.website}`;
         this.state.username = res.data.username;
-        this.state.tokenData = value;
+        this.state.token = value.access_token;
         LoginService.setAccountData(this.props.account._id, this.state ).then(
           () => {
             message.success(`${this.state.website} authenticated.`);

--- a/ui/src/websites/website-registry.ts
+++ b/ui/src/websites/website-registry.ts
@@ -24,6 +24,7 @@ import { Manebooru } from './manebooru/Manebooru';
 import { Mastodon } from './mastodon/Mastodon';
 import { MissKey } from './misskey/MissKey';
 import { Pillowfort } from './pillowfort/Pillowfort';
+import { Pleroma } from './pleroma/Pleroma';
 import { Telegram } from './telegram/Telegram';
 import { Furbooru } from './furbooru/Furbooru';
 import { Itaku } from './itaku/Itaku';
@@ -59,6 +60,7 @@ export class WebsiteRegistry {
     Pillowfort: new Pillowfort(),
     Pixelfed: new Pixelfed(),
     Pixiv: new Pixiv(),
+    Pleroma: new Pleroma(),
     SoFurry: new SoFurry(),
     SubscribeStar: new SubscribeStar(),
     SubscribeStarAdult: new SubscribeStarAdult(),


### PR DESCRIPTION
Lot of refactoring to move Pixelfed, Mastodon and Pleroma onto a common code structure entirely, removing a LOT of duplication.

This is forked from my Pleroma branch, and *should* fully support Pleroma with no issues now - as does NOT use the Mastodon compatibility API at all. I've tested this with my own Pleroma test instance and didn't get any issues. 

Bump Megalodon to v7; will move to v8 once I have moved misskey off to it's own lib.