### PR TITLE
Warn about tags that don't fit into description

### DIFF
--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -341,7 +341,7 @@ export class Bluesky extends Website {
       );
     }
 
-    this.validateDescriptionLength(problems, submissionPart, defaultPart);
+    this.validateDescription(problems, warnings, submissionPart, defaultPart);
 
     const files = [
       submission.primary,
@@ -398,14 +398,15 @@ export class Bluesky extends Website {
     const problems: string[] = [];
     const warnings: string[] = [];
 
-    this.validateDescriptionLength(problems, submissionPart, defaultPart);
+    this.validateDescription(problems, warnings, submissionPart, defaultPart);
     this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
 
     return { problems, warnings };
   }
 
-  private validateDescriptionLength(
+  private validateDescription(
     problems: string[],
+    warnings: string[],
     submissionPart: SubmissionPart<BlueskyNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
   ): void {
@@ -420,6 +421,14 @@ export class Bluesky extends Website {
     if (rt.graphemeLength > this.MAX_CHARS) {
       problems.push(
         `Max description length allowed is ${this.MAX_CHARS} characters.`,
+      );
+    } else {
+      this.validateAppendTags(
+        warnings,
+        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        description,
+        this.MAX_CHARS,
+        getRichTextLength,
       );
     }
   }

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -213,6 +213,13 @@ export abstract class Megalodon extends Website {
       warnings.push(
         `Max description length allowed is ${this.maxCharLength} characters.`,
       );
+    } else {
+      this.validateAppendTags(
+        warnings,
+        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        description,
+        this.maxCharLength,
+      );
     }
 
     const files = [
@@ -291,6 +298,13 @@ export abstract class Megalodon extends Website {
     if (description.length > this.maxCharLength) {
       warnings.push(
         `Max description length allowed is ${this.maxCharLength} characters.`,
+      );
+    } else {
+      this.validateAppendTags(
+        warnings,
+        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        description,
+        this.maxCharLength,
       );
     }
 

--- a/electron-app/src/server/websites/misskey/misskey.service.ts
+++ b/electron-app/src/server/websites/misskey/misskey.service.ts
@@ -246,6 +246,13 @@ export class MissKey extends Website {
       warnings.push(
         `Max description length allowed is ${maxChars} characters (for this MissKey client).`,
       );
+    } else {
+      this.validateAppendTags(
+        warnings,
+        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        description,
+        maxChars
+      );
     }
 
     const files = [
@@ -319,6 +326,13 @@ export class MissKey extends Website {
     if (description.length > maxChars) {
       warnings.push(
         `Max description length allowed is ${maxChars} characters (for this MissKey client).`,
+      );
+    } else {
+      this.validateAppendTags(
+        warnings,
+        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        description,
+        maxChars
       );
     }
 


### PR DESCRIPTION
On Bluesky, Mastodon and Misskey, rather than just silently truncating tags to some unexpected subset.