### PR TITLE
Tag shortcut expansion

### DIFF
--- a/commons/src/interfaces/submission/tag-data.interface.ts
+++ b/commons/src/interfaces/submission/tag-data.interface.ts
@@ -1,4 +1,5 @@
 export interface TagData {
   extendDefault: boolean;
   value: string[];
+  appendTags: boolean;
 }

--- a/commons/src/models/default-options.entity.ts
+++ b/commons/src/models/default-options.entity.ts
@@ -39,6 +39,7 @@ export class DefaultOptionsEntity implements DefaultOptions {
     this.tags = {
       value: [],
       extendDefault: true,
+      appendTags: true
     };
 
     this.description = {

--- a/electron-app/src/server/submission/parser/parser.service.ts
+++ b/electron-app/src/server/submission/parser/parser.service.ts
@@ -42,7 +42,7 @@ export class ParserService {
     private readonly fileManipulator: FileManipulationService,
     websitesService: WebsitesService,
   ) {
-    this.descriptionParser = new DescriptionParser(customShortcuts, websitesService, settings);
+    this.descriptionParser = new DescriptionParser(customShortcuts, websitesService, settings, this);
   }
 
   public async parse(

--- a/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
+++ b/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
@@ -8,6 +8,7 @@ import FormContent from 'src/server/utils/form-content.util';
 import { Website } from 'src/server/websites/website.base';
 import { WebsitesService } from 'src/server/websites/websites.service';
 import SubmissionPartEntity from '../../submission-part/models/submission-part.entity';
+import { ParserService } from '../parser.service';
 
 interface ShortcutData {
   originalText: string;
@@ -26,6 +27,7 @@ export class DescriptionParser {
     private customShortcuts: CustomShortcutService,
     private websitesService: WebsitesService,
     private settings: SettingsService,
+    private readonly parserService: ParserService
   ) {
     this.websiteDescriptionShortcuts = websitesService.getUsernameShortcuts();
     this.websiteDescriptionShortcuts = {
@@ -52,6 +54,7 @@ export class DescriptionParser {
 
     if (description.length) {
       // Insert {default}, {title}, {tags} shortcuts
+      let tags = await this.parserService.parseTags(website, defaultPart, websitePart);
       description = this.insertDefaultShortcuts(description, [
         {
           name: 'default',
@@ -64,8 +67,7 @@ export class DescriptionParser {
         {
           name: 'tags',
           content:
-            defaultPart.data.tags.value.map(t => '#' + t).join(' ') ??
-            websitePart.data.tags.value.map(t => '#' + t).join(' ') ??
+            tags.map(t => '#' + t).join(' ') ??
             '',
         },
       ]);

--- a/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
+++ b/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
@@ -66,9 +66,7 @@ export class DescriptionParser {
         },
         {
           name: 'tags',
-          content:
-           website.formatTags(tags) ??
-            '',
+          content: (website.formatTags(tags) ?? '').toString().replaceAll(",", " ")
         },
       ]);
 

--- a/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
+++ b/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
@@ -67,7 +67,7 @@ export class DescriptionParser {
         {
           name: 'tags',
           content:
-            tags.map(t => '#' + t).join(' ') ??
+           website.formatTags(tags) ??
             '',
         },
       ]);

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -28,7 +28,6 @@ import { Website } from '../website.base';
 import {  BskyAgent, stringifyLex, jsonToLex, AppBskyEmbedImages, AppBskyRichtextFacet, ComAtprotoLabelDefs, BlobRef, RichText} from '@atproto/api';
 import { PlaintextParser } from 'src/server/description-parsing/plaintext/plaintext.parser';
 import fetch from "node-fetch";
-import Graphemer from 'graphemer';
 import { ReplyRef } from '@atproto/api/dist/client/types/app/bsky/feed/post';
 import FormContent from 'src/server/utils/form-content.util';
 
@@ -229,7 +228,10 @@ export class Bluesky extends Website {
       $type: 'app.bsky.embed.images',
     };
 
-    const status = this.appendRichTextTags(data.tags, data.description);
+    let status = data.description;
+    if (data.options.tags.appendTags) {
+      status = this.appendRichTextTags(data.tags, data.description);
+    }
 
     let labelsRecord: ComAtprotoLabelDefs.SelfLabels | undefined;
     if (data.options.label_rating) {
@@ -286,7 +288,10 @@ export class Bluesky extends Website {
     let profile = await agent.getProfile({actor: agent.session.did });
 
     const reply = await this.getReplyRef(agent, data.options.replyToUrl);
-    const status = this.appendRichTextTags(data.tags, data.description);
+    let status = data.description;
+    if (data.options.tags.appendTags) {
+      status = this.appendRichTextTags(data.tags, data.description);
+    }
 
     let labelsRecord: ComAtprotoLabelDefs.SelfLabels | undefined;
     if (data.options.label_rating) {
@@ -423,13 +428,15 @@ export class Bluesky extends Website {
         `Max description length allowed is ${this.MAX_CHARS} characters.`,
       );
     } else {
-      this.validateAppendTags(
-        warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
-        description,
-        this.MAX_CHARS,
-        getRichTextLength,
-      );
+      if (submissionPart.data.tags.appendTags) {
+        this.validateAppendTags(
+          warnings,
+          this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+          description,
+          this.MAX_CHARS,
+          getRichTextLength,
+        );
+      }
     }
   }
 

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -131,7 +131,9 @@ export abstract class Megalodon extends Website {
         statusOptions.spoiler_text = data.options.spoilerText;
       }
 
-      status = this.appendTags(this.formatTags(data.tags), status, this.maxCharLength);
+      if (data.options.tags.appendTags) {
+        status = this.appendTags(this.formatTags(data.tags), status, this.maxCharLength);
+      }
 
       try {
         const result = (await M.postStatus(status, statusOptions)).data as Entity.Status;
@@ -174,7 +176,10 @@ export abstract class Megalodon extends Website {
     if (data.options.spoilerText) {
       statusOptions.spoiler_text = data.options.spoilerText;
     }
-    status = this.appendTags(this.formatTags(data.tags), status, this.maxCharLength);
+
+    if (data.options.tags.appendTags) {
+      status = this.appendTags(this.formatTags(data.tags), status, this.maxCharLength);
+    }
 
     const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);
     if (replyToId) {
@@ -217,12 +222,14 @@ export abstract class Megalodon extends Website {
         `Max description length allowed is ${this.maxCharLength} characters.`,
       );
     } else {
-      this.validateAppendTags(
-        warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
-        description,
-        this.maxCharLength,
-      );
+      if (submissionPart.data.tags.appendTags) {
+        this.validateAppendTags(
+          warnings,
+          this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+          description,
+          this.maxCharLength,
+        );
+      }
     }
 
     const files = [
@@ -303,12 +310,14 @@ export abstract class Megalodon extends Website {
         `Max description length allowed is ${this.maxCharLength} characters.`,
       );
     } else {
-      this.validateAppendTags(
-        warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
-        description,
-        this.maxCharLength,
-      );
+      if (submissionPart.data.tags.appendTags) {
+        this.validateAppendTags(
+          warnings,
+          this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+          description,
+          this.maxCharLength,
+        );
+      }
     }
 
     this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);

--- a/electron-app/src/server/websites/website.base.ts
+++ b/electron-app/src/server/websites/website.base.ts
@@ -126,7 +126,7 @@ export abstract class Website {
       .map(tag => tag.replace(/\s/g, options.spaceReplacer).trim());
   }
 
-  protected formatTags(tags: string[], options?: TagParseOptions): any {
+  formatTags(tags: string[], options?: TagParseOptions): any {
     return this.parseTags(tags, options);
   }
 

--- a/ui/src/views/submissions/submission-forms/form-components/TagInput.tsx
+++ b/ui/src/views/submissions/submission-forms/form-components/TagInput.tsx
@@ -12,6 +12,7 @@ export interface TagOptions {
   minTags?: number;
   mode?: 'count' | 'length';
   maxLength?: number;
+  showDisableAppending?: boolean;
 }
 
 interface Props {
@@ -39,12 +40,14 @@ export default class TagInput extends React.Component<Props, State> {
 
   private data: TagData = {
     extendDefault: true,
-    value: []
+    value: [],
+    appendTags: true
   };
 
   options: TagOptions = {
     maxTags: 200,
-    mode: 'count'
+    mode: 'count',
+    showDisableAppending: false
   };
 
   constructor(props: Props) {
@@ -61,6 +64,11 @@ export default class TagInput extends React.Component<Props, State> {
 
   changeExtendDefault = (checked: boolean) => {
     this.data.extendDefault = checked;
+    this.update();
+  };
+
+  changeShowDisableAppending = (checked: boolean) => {
+    this.data.appendTags = checked;
     this.update();
   };
 
@@ -85,6 +93,7 @@ export default class TagInput extends React.Component<Props, State> {
   update() {
     this.props.onChange({
       extendDefault: this.data.extendDefault,
+      appendTags: this.data.appendTags,
       value: this.filterTags(this.data.value)
     });
   }
@@ -123,6 +132,19 @@ export default class TagInput extends React.Component<Props, State> {
       </div>
     );
 
+    const appendSwitch = this.options.showDisableAppending ? (
+      <div>
+        <span className="mr-2">
+          <Switch
+            size="small"
+            checked={this.props.defaultValue.appendTags}
+            onChange={this.changeShowDisableAppending}
+          />
+        </span>
+        <span>Append tags to Description</span>
+      </div>      
+    ) : null
+
     const selectOptions = _.uniq([
       ...(this.state.suggestions || []),
       ...(this.props.defaultValue.value || [])
@@ -134,6 +156,7 @@ export default class TagInput extends React.Component<Props, State> {
     return (
       <Form.Item label={this.props.label} required={!!this.options.minTags}>
         {tagSwitch}
+        {appendSwitch}
         <div className="flex">
           <Select
             mode="tags"

--- a/ui/src/views/submissions/submission-forms/forms/MultiSubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/MultiSubmissionEditForm.tsx
@@ -55,7 +55,8 @@ class MultiSubmissionEditForm extends React.Component<Props, MultiSubmissionEdit
   private defaultOptions: DefaultOptions = {
     tags: {
       extendDefault: false,
-      value: []
+      value: [],
+      appendTags: true
     },
     description: {
       overwriteDefault: false,

--- a/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
@@ -77,7 +77,8 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
   private defaultOptions: DefaultOptions = {
     tags: {
       extendDefault: false,
-      value: []
+      value: [],
+      appendTags: true
     },
     description: {
       overwriteDefault: false,

--- a/ui/src/views/submissions/submission-forms/forms/SubmissionTemplateEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/SubmissionTemplateEditForm.tsx
@@ -41,7 +41,8 @@ class SubmissionTemplateEditForm extends React.Component<Props, SubmissionTempla
   private defaultOptions: DefaultOptions = {
     tags: {
       extendDefault: false,
-      value: []
+      value: [],
+      appendTags: true
     },
     description: {
       overwriteDefault: false,

--- a/ui/src/views/tag-groups/TagGroups.tsx
+++ b/ui/src/views/tag-groups/TagGroups.tsx
@@ -140,7 +140,7 @@ class TagGroupInput extends React.Component<TagGroup, TagGroupInputState> {
               hideExtend={true}
               hideExtra={true}
               hideTagGroup={true}
-              defaultValue={{ extendDefault: false, value: this.state.tagGroup.tags! }}
+              defaultValue={{ extendDefault: false, value: this.state.tagGroup.tags!, appendTags: true }}
             />
           </Card>
         </Spin>

--- a/ui/src/websites/bluesky/Bluesky.tsx
+++ b/ui/src/websites/bluesky/Bluesky.tsx
@@ -28,7 +28,7 @@ export class Bluesky extends WebsiteImpl {
     <BlueskyFileSubmissionForm
       key={props.part.accountId}
       {...props}
-      tagOptions={{ show: true }}
+      tagOptions={{ show: true, options: { showDisableAppending: true } }}
       hideThumbnailOptions={true}
     />
   );
@@ -39,7 +39,7 @@ export class Bluesky extends WebsiteImpl {
     <BlueskyNotificationSubmissionForm
       key={props.part.accountId}
       {...props}
-      tagOptions={{ show: true }}
+      tagOptions={{ show: true, options: { showDisableAppending: true } }}
     />
   );
 }

--- a/ui/src/websites/mastodon/Mastodon.tsx
+++ b/ui/src/websites/mastodon/Mastodon.tsx
@@ -35,7 +35,7 @@ export class Mastodon extends WebsiteImpl {
           { name: 'Sensitive', value: SubmissionRating.ADULT }
         ]
       }}
-      tagOptions={{ show: true }}
+      tagOptions={{ show: true, options: { showDisableAppending: true } }}
       hideThumbnailOptions={true}
     />
   );
@@ -53,7 +53,7 @@ export class Mastodon extends WebsiteImpl {
           { name: 'Sensitive', value: SubmissionRating.ADULT }
         ]
       }}
-      tagOptions={{ show: true }}
+      tagOptions={{ show: true, options: { showDisableAppending: true } }}
     />
   );
 }

--- a/ui/src/websites/pixelfed/Pixelfed.tsx
+++ b/ui/src/websites/pixelfed/Pixelfed.tsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { WebsiteSectionProps } from '../form-sections/website-form-section.interface';
 import GenericFileSubmissionSection from '../generic/GenericFileSubmissionSection';
 import { GenericSelectProps } from '../generic/GenericSelectProps';
-import GenericSubmissionSection from '../generic/GenericSubmissionSection';
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { WebsiteImpl } from '../website.base';
 import PixelfedLogin from './PixelfedLogin';
@@ -34,7 +33,7 @@ export class Pixelfed extends WebsiteImpl {
           { name: 'Sensitive', value: SubmissionRating.ADULT }
         ]
       }}
-      tagOptions={{ show: true }}
+      tagOptions={{ show: true, options: { showDisableAppending: true } }}
       hideThumbnailOptions={true}
     />
   );


### PR DESCRIPTION
This resolves a couple of issues around using the {tags} shortcut in descriptions for services such as Mastodon, Pleroma, Bluesky etc

The {tags} shortcut was not going through the convertors, so was not parsing properly, it also was not parsing out spaces correctly (i.e. website specific adaptions).

Also added an option to the sites that we are currently appending the tags automatically onto descriptions on to allow turning this off for people that might be using the {tags} shortcut to avoid duplication.