### PR TITLE
Allow specifying alt texts in submission files

### DIFF
--- a/commons/src/interfaces/submission/file-record.interface.ts
+++ b/commons/src/interfaces/submission/file-record.interface.ts
@@ -13,4 +13,5 @@ export interface FileRecord {
   type: FileSubmissionType;
   ignoredAccounts?: string[];
   buffer?: Buffer;
+  altText?: string;
 }

--- a/commons/src/interfaces/submission/submission-update.interface.ts
+++ b/commons/src/interfaces/submission/submission-update.interface.ts
@@ -5,4 +5,5 @@ export interface SubmissionUpdate {
   parts: SubmissionPart<any>[];
   removedParts: string[]; // list of SubmissionPart ids
   postAt?: number;
+  altTexts: { [key: string]: string };
 }

--- a/electron-app/src/server/submission/file-submission/file-submission.service.ts
+++ b/electron-app/src/server/submission/file-submission/file-submission.service.ts
@@ -213,6 +213,7 @@ export class FileSubmissionService {
       ignoredAccounts: [],
       height: 0,
       width: 0,
+      altText: '',
     };
 
     if (file.mimetype.includes('image/jpeg') || file.mimetype.includes('image/png')) {

--- a/electron-app/src/server/submission/parser/parser.service.ts
+++ b/electron-app/src/server/submission/parser/parser.service.ts
@@ -186,6 +186,7 @@ export class ParserService {
           filename: this.parseFileName(file.name),
         },
       },
+      altText: file.altText || '',
     };
   }
 

--- a/electron-app/src/server/submission/post/interfaces/file-post-data.interface.ts
+++ b/electron-app/src/server/submission/post/interfaces/file-post-data.interface.ts
@@ -12,6 +12,7 @@ export interface FilePostData<T extends DefaultFileOptions> extends PostData<Fil
 export interface PostFileRecord {
   type: FileSubmissionType;
   file: PostFile;
+  altText: string;
 }
 
 export interface PostFile {

--- a/electron-app/src/server/submission/submission.service.ts
+++ b/electron-app/src/server/submission/submission.service.ts
@@ -546,6 +546,17 @@ export class SubmissionService {
     if (!postAt) {
       submissionToUpdate.schedule.isScheduled = false;
     }
+
+    if (submissionToUpdate.type === SubmissionType.FILE && update.altTexts) {
+      const fileSubmission = submissionToUpdate as FileSubmissionEntity;
+      for (const fileRecord of [fileSubmission.primary, ...(fileSubmission.additional || [])]) {
+        const altText = update.altTexts[fileRecord.location];
+        if (altText !== undefined && altText != fileRecord.altText) {
+          fileRecord.altText = altText;
+        }
+      }
+    }
+
     await this.repository.update(submissionToUpdate);
 
     await Promise.all(removedParts.map(partId => this.partService.removeSubmissionPart(partId)));

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -101,7 +101,9 @@ export abstract class Megalodon extends Website {
     const uploadedMedias: string[] = [];
     for (const file of files) {
       this.checkCancelled(cancellationToken);
-      uploadedMedias.push(await this.uploadMedia(accountData, file.file, data.options.altText));
+      uploadedMedias.push(
+        await this.uploadMedia(accountData, file.file, file.altText || data.options.altText),
+      );
     }
 
     const isSensitive = data.rating !== SubmissionRating.GENERAL;

--- a/electron-app/src/server/websites/misskey/misskey.service.ts
+++ b/electron-app/src/server/websites/misskey/misskey.service.ts
@@ -120,7 +120,9 @@ export class MissKey extends Website {
     const uploadedMedias: string[] = [];
     for (const file of files) {
       this.checkCancelled(cancellationToken);
-      const upload = await M.uploadMedia(file.file.value, { description: data.options.altText });
+      const upload = await M.uploadMedia(file.file.value, {
+        description: file.altText || data.options.altText,
+      });
       if (upload.status > 300) {
         return Promise.reject(
           this.createPostResponse({ additionalInfo: upload.status, message: upload.statusText }),

--- a/ui/src/websites/bluesky/Bluesky.tsx
+++ b/ui/src/websites/bluesky/Bluesky.tsx
@@ -88,7 +88,7 @@ export class BlueskyFileSubmissionForm extends GenericFileSubmissionSection<Blue
           <Select.Option value={'porn'}>Adult: Porn</Select.Option>
         </Select>
       </Form.Item>,
-      <Form.Item label="Alt Text">
+      <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}
           onChange={this.handleValueChange.bind(this, 'altText')}

--- a/ui/src/websites/mastodon/Mastodon.tsx
+++ b/ui/src/websites/mastodon/Mastodon.tsx
@@ -117,7 +117,7 @@ export class MastodonFileSubmissionForm extends GenericFileSubmissionSection<Mas
           onChange={this.handleValueChange.bind(this, 'spoilerText')}
         />
       </Form.Item>,
-      <Form.Item label="Alt Text">
+      <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}
           onChange={this.handleValueChange.bind(this, 'altText')}

--- a/ui/src/websites/misskey/MissKey.tsx
+++ b/ui/src/websites/misskey/MissKey.tsx
@@ -114,7 +114,7 @@ export class MissKeyFileSubmissionForm extends GenericFileSubmissionSection<Miss
           onChange={this.handleValueChange.bind(this, 'spoilerText')}
         />
       </Form.Item>,
-      <Form.Item label="Alt Text">
+      <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}
           onChange={this.handleValueChange.bind(this, 'altText')}

--- a/ui/src/websites/pixelfed/Pixelfed.tsx
+++ b/ui/src/websites/pixelfed/Pixelfed.tsx
@@ -58,7 +58,7 @@ export class PixelfedFileSubmissionForm extends GenericFileSubmissionSection<Pix
           onChange={this.handleValueChange.bind(this, 'spoilerText')}
         />
       </Form.Item>,
-      <Form.Item label="Alt Text">
+      <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}
           onChange={this.handleValueChange.bind(this, 'altText')}


### PR DESCRIPTION
Rather than having a single alt text field in individual website forms that then get copied for every uploaded file and then causes a screen reader to rattle off the same description multiple times. Alt text fields in the individual forms are still present for compatibility, but they will only be used as fallback if no file-specific values are provided.

Ping @aneillans because if I recall correctly you had something like this in mind too.