### PR TITLE
Strongly typed formatTags, reworked to make sure returns were all valid.

### DIFF
--- a/electron-app/src/server/websites/aryion/aryion.service.ts
+++ b/electron-app/src/server/websites/aryion/aryion.service.ts
@@ -128,7 +128,7 @@ export class Aryion extends Website {
       file: postFile,
       thumb: data.thumbnail,
       desc: data.description,
-      tags: this.formatTags(data.tags)
+      tags: this.parseTags(data.tags)
         .filter(f => !f.match(/^vore$/i))
         .filter(f => !f.match(/^non-vore$/i))
         .join('\n'),

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -164,11 +164,11 @@ export class Bluesky extends Website {
     };
   }
 
-  formatTags(tags: string[]) {
+  formatTags(tags: string[]): string {
     return this.parseTags(
       tags.map(tag => tag.replace(/[^a-z0-9]/gi, ' ')).map(tag => tag.split(' ').join('')),
       { spaceReplacer: '_' },
-    ).map(tag => `#${tag}`);
+    ).map(tag => `#${tag}`).join(' ');
   }
 
   private async uploadMedia(
@@ -419,7 +419,7 @@ export class Bluesky extends Website {
       if (description.toLowerCase().indexOf('{tags}') > -1) {
         this.validateInsertTags(
           warnings,
-          this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+          this.parseTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
           description,
           this.MAX_CHARS,
           getRichTextLength,

--- a/electron-app/src/server/websites/deviant-art/deviant-art.service.ts
+++ b/electron-app/src/server/websites/deviant-art/deviant-art.service.ts
@@ -175,11 +175,11 @@ export class DeviantArt extends Website {
     return text.replace(/<p/gm, '<div').replace(/<\/p>/gm, '</div>').replace(/\n/g, '<br>');
   }
 
-  formatTags(tags: string[]): string[] {
+  formatTags(tags: string[]): string {
     tags = super.parseTags(tags);
     if (tags.length > this.MAX_TAGS) {
-      return tags.slice(0, this.MAX_TAGS - 1);
-    } else return tags;
+      return tags.slice(0, this.MAX_TAGS - 1).join(' ');
+    } else return tags.join(' ');
   }
 
   async postFileSubmission(
@@ -194,7 +194,7 @@ export class DeviantArt extends Website {
       artist_comments: data.description,
     };
 
-    this.formatTags(data.tags)
+    this.parseTags(data.tags)
       .map(t => t.replace(/\//g, '_'))
       .forEach((t, i) => {
         uploadForm[`tags[${i}]`] = t;

--- a/electron-app/src/server/websites/e621/e621.service.ts
+++ b/electron-app/src/server/websites/e621/e621.service.ts
@@ -144,8 +144,8 @@ export class e621 extends Website {
     }
   }
 
-  formatTags(tags: string[]) {
-    return super.formatTags(tags).join(' ').trim();
+  formatTags(tags: string[]): string{
+    return super.formatTags(tags);
   }
 
   transformAccountData(data: e621AccountData) {

--- a/electron-app/src/server/websites/furry-network/furry-network.service.ts
+++ b/electron-app/src/server/websites/furry-network/furry-network.service.ts
@@ -418,9 +418,9 @@ export class FurryNetwork extends Website {
     }
   }
 
-  formatTags(tags: string[]) {
+  formatTags(tags: string[]): string {
     return super
-      .formatTags(tags, { spaceReplacer: '-', maxLength: 30, minLength: 3 })
+      .parseTags(tags, { spaceReplacer: '-', maxLength: 30, minLength: 3 })
       .map(tag =>
         tag
           .replace(/(\(|\)|:|#|;|\]|\[|\.|')/g, '')
@@ -428,7 +428,7 @@ export class FurryNetwork extends Website {
           .replace(/\?/g, 'unknown'),
       )
       .filter(tag => tag.length >= 3)
-      .slice(0, 30);
+      .slice(0, 30).join(' ');
   }
 
   validateFileSubmission(

--- a/electron-app/src/server/websites/furtastic/furtastic.service.ts
+++ b/electron-app/src/server/websites/furtastic/furtastic.service.ts
@@ -115,8 +115,8 @@ export class Furtastic extends Website {
     }
   }
 
-  formatTags(tags: string[]) {
-    return super.formatTags(tags).join(' ').trim();
+  formatTags(tags: string[]): string {
+    return super.formatTags(tags);
   }
 
   transformAccountData(data: FurtasticAccountData) {

--- a/electron-app/src/server/websites/hentai-foundry/hentai-foundry.service.ts
+++ b/electron-app/src/server/websites/hentai-foundry/hentai-foundry.service.ts
@@ -139,9 +139,9 @@ export class HentaiFoundry extends Website {
     return Promise.reject(this.createPostResponse({ additionalInfo: post.body }));
   }
 
-  formatTags(tags: string[]) {
+  formatTags(tags: string[]): string {
     const maxLength = 500;
-    const t = super.formatTags(tags);
+    const t = super.parseTags(tags)
     let tagString = t.join(', ').trim();
 
     return tagString.length > maxLength

--- a/electron-app/src/server/websites/inkbunny/inkbunny.service.ts
+++ b/electron-app/src/server/websites/inkbunny/inkbunny.service.ts
@@ -219,8 +219,8 @@ export class Inkbunny extends Website {
     });
   }
 
-  formatTags(tags: string[]) {
-    return super.formatTags(tags).join(',').trim();
+  formatTags(tags: string[]): string {
+    return super.parseTags(tags).join(',').trim();
   }
 
   transformAccountData(data: InkbunnyAccountData) {

--- a/electron-app/src/server/websites/ko-fi/ko-fi.service.ts
+++ b/electron-app/src/server/websites/ko-fi/ko-fi.service.ts
@@ -160,8 +160,8 @@ export class KoFi extends Website {
     return this.createPostResponse({});
   }
 
-  formatTags(tags: string[]) {
-    return super.formatTags(tags).join(',');
+  formatTags(tags: string[]): string {
+    return super.formatTags(tags);
   }
 
   validateFileSubmission(

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -92,7 +92,7 @@ export abstract class Megalodon extends Website {
   ) : string {
     const instanceSettings = this.getInstanceSettings(websitePart.accountId);
     const { includedTags } = this.calculateFittingTags(tags, description, instanceSettings.maxChars);
-    return this.formatTags(includedTags).join(' ') ?? ''
+    return this.formatTags(includedTags) ?? ''
   }
 
   abstract getScalingOptions(file: FileRecord, accountId: string): ScalingOptions;
@@ -200,11 +200,11 @@ export abstract class Megalodon extends Website {
     }
   }
 
-  formatTags(tags: string[]) {
+  formatTags(tags: string[]): string {
     return this.parseTags(
       tags.map(tag => tag.replace(/[^a-z0-9]/gi, ' ')).map(tag => tag.split(' ').join('')),
       { spaceReplacer: '_' },
-    ).map(tag => `#${tag}`);
+    ).map(tag => `#${tag}`).join(' ');
   }
 
   validateFileSubmission(
@@ -229,7 +229,7 @@ export abstract class Megalodon extends Website {
     } else {
       this.validateInsertTags(
         warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        this.parseTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
         description,
         instanceSettings.maxChars,
       );
@@ -315,7 +315,7 @@ export abstract class Megalodon extends Website {
     } else {
       this.validateInsertTags(
         warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        this.parseTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
         description,
         instanceSettings.maxChars,
       );

--- a/electron-app/src/server/websites/misskey/misskey.service.ts
+++ b/electron-app/src/server/websites/misskey/misskey.service.ts
@@ -210,7 +210,7 @@ export class MissKey extends Website {
     }
   }
 
-  formatTags(tags: string[]) {
+  formatTags(tags: string[]): string {
     return this.parseTags(
       tags
         .map(tag => tag.replace(/[^a-z0-9]/gi, ' '))
@@ -221,7 +221,7 @@ export class MissKey extends Website {
             .join(''),
         ),
       { spaceReplacer: '_' },
-    ).map(tag => `#${tag}`);
+    ).map(tag => `#${tag}`).join (' ');
   }
 
   validateFileSubmission(
@@ -247,7 +247,7 @@ export class MissKey extends Website {
     } else {
       this.validateInsertTags(
         warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        this.parseTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
         description,
         maxChars
       );
@@ -325,7 +325,7 @@ export class MissKey extends Website {
     } else {
       this.validateInsertTags(
         warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+        this.parseTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
         description,
         maxChars
       );

--- a/electron-app/src/server/websites/newgrounds/newgrounds.service.ts
+++ b/electron-app/src/server/websites/newgrounds/newgrounds.service.ts
@@ -282,7 +282,7 @@ export class Newgrounds extends Website {
           encoder: 'quill',
           title: data.title,
           'option[longdescription]': this.parseDescription(data.description),
-          'option[tags]': this.formatTags(data.tags).join(','),
+          'option[tags]': this.formatTags(data.tags),
           'option[include_in_portal]': options.sketch ? '0' : '1',
           'option[use_creative_commons]': options.creativeCommons ? '1' : '0',
           'option[cc_commercial]': options.commercial ? 'yes' : 'no',
@@ -351,13 +351,13 @@ export class Newgrounds extends Website {
     }
   }
 
-  formatTags(tags: string[]): any {
+  formatTags(tags: string[]): string {
     return super
-      .formatTags(tags, { spaceReplacer: '-' })
+      .parseTags(tags, { spaceReplacer: '-' })
       .map(tag => {
         return tag.replace(/(\(|\)|:|#|;|\]|\[|')/g, '').replace(/_/g, '-');
       })
-      .slice(0, 12);
+      .slice(0, 12).join(',');
   }
 
   validateFileSubmission(

--- a/electron-app/src/server/websites/picarto/picarto.service.ts
+++ b/electron-app/src/server/websites/picarto/picarto.service.ts
@@ -227,7 +227,7 @@ export class Picarto extends Website {
             schedule_publishing_time: '',
             schedule_publishing_timezone: '',
             software: data.options.softwares.join(','),
-            tags: this.formatTags(data.tags).join(','),
+            tags: this.formatTags(data.tags),
             title: data.title,
             variations: variations.join(','),
             visibility: data.options.visibility,
@@ -252,11 +252,11 @@ export class Picarto extends Website {
     return this.createPostResponse({});
   }
 
-  formatTags(tags: string[]) {
+  formatTags(tags: string[]): string {
     return super
-      .formatTags(tags, { spaceReplacer: '_', maxLength: 30, minLength: 1 })
+      .parseTags(tags, { spaceReplacer: '_', maxLength: 30, minLength: 1 })
       .filter(tag => tag.length >= 1)
-      .slice(0, 30);
+      .slice(0, 30).join(',');
   }
 
   validateFileSubmission(

--- a/electron-app/src/server/websites/pixiv/pixiv.service.ts
+++ b/electron-app/src/server/websites/pixiv/pixiv.service.ts
@@ -219,7 +219,7 @@ export class Pixiv extends Website {
       x_restrict_sexual: this.getContentRatingLegacy(data.rating),
       sexual: '',
       title: data.title.substring(0, 32),
-      tag: this.formatTags(data.tags).slice(0, 10).join(' '),
+      tag: this.parseTags(data.tags).slice(0, 10).join(' '),
       comment: data.description,
       rating: '1',
       mode: 'upload',

--- a/electron-app/src/server/websites/weasyl/weasyl.service.ts
+++ b/electron-app/src/server/websites/weasyl/weasyl.service.ts
@@ -312,8 +312,8 @@ export class Weasyl extends Website {
     this.accountInformation.set(id, { folders: convertedFolders });
   }
 
-  formatTags(tags: string[]) {
-    return super.formatTags(tags).join(' ');
+  formatTags(tags: string[]): string {
+    return super.formatTags(tags);
   }
 
   validateFileSubmission(

--- a/electron-app/src/server/websites/website.base.ts
+++ b/electron-app/src/server/websites/website.base.ts
@@ -128,8 +128,8 @@ export abstract class Website {
       .map(tag => tag.replace(/\s/g, options.spaceReplacer).trim());
   }
 
-  formatTags(tags: string[], options?: TagParseOptions): any {
-    return this.parseTags(tags, options);
+  formatTags(tags: string[], options?: TagParseOptions): string {
+    return this.parseTags(tags, options).join(', ').trim();
   }
 
   validateInsertTags(
@@ -162,8 +162,22 @@ export abstract class Website {
     description: string,
     websitePart: SubmissionPartEntity<DefaultOptions>,
   ) : string {
+    this.logger.debug(`Max Char Count: ${this.MAX_CHARS}`);
+    if (this.MAX_CHARS === undefined) {
+      this.logger.debug(`generateTagsString: tags contains ${tags.length} items`);
+      console.log(tags);
+      let t = this.parseTags(tags);
+      if (t.length > 0) { 
+        return this.formatTags(t); 
+      }
+      return '';
+    }
+
     const { includedTags } = this.calculateFittingTags(tags, description, this.MAX_CHARS);
-    return this.formatTags(includedTags).join(' ') ?? ''
+  
+    this.logger.debug(`generateTagsString: includedTags contains ${includedTags.length} items`);
+    console.log(includedTags);
+    return this.formatTags(includedTags) ?? ''
   }
 
   protected calculateFittingTags(


### PR DESCRIPTION
Resolves issue with FurAffinity etc as mentioned by users on Discord following the Tag parse refactor; also cleaned up some of the code around this generally, strongly typed formatTags, forced any other bugs to come to the surface and *hopefully* squashed them too.