### PR TITLE
Handle undefined Bluesky threadgate value properly

### DIFF
--- a/commons/src/interfaces/websites/bluesky/bluesky.file.options.interface.ts
+++ b/commons/src/interfaces/websites/bluesky/bluesky.file.options.interface.ts
@@ -4,5 +4,5 @@ export interface BlueskyFileOptions extends DefaultFileOptions {
   altText?: string;
   label_rating: string;
   replyToUrl?: string;
-  threadgate: string;
+  threadgate?: string;
 }

--- a/commons/src/interfaces/websites/bluesky/bluesky.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/bluesky/bluesky.notification.options.interface.ts
@@ -3,5 +3,5 @@ import { DefaultOptions } from '../../submission/default-options.interface';
 export interface BlueskyNotificationOptions extends DefaultOptions {
   label_rating: string;
   replyToUrl?: string;
-  threadgate: string;
+  threadgate?: string;
 }

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -263,7 +263,7 @@ export class Bluesky extends Website {
       let friendlyUrl = `https://${server}/profile/${handle}/post/${postId}`;
 
       // After the post has been made, check to see if we need to set a ThreadGate; these are the options to control who can reply to your post, and need additional calls
-      if (data.options.threadgate !== "") {
+      if (data.options.threadgate) {
         this.createThreadgate(agent, postResult.uri, data.options.threadgate);
       }
 
@@ -359,7 +359,7 @@ export class Bluesky extends Website {
       let friendlyUrl = `https://${server}/profile/${handle}/post/${postId}`;
 
       // After the post has been made, check to see if we need to set a ThreadGate; these are the options to control who can reply to your post, and need additional calls
-      if (data.options.threadgate != "") {
+      if (data.options.threadgate) {
         this.createThreadgate(agent, postResult.uri, data.options.threadgate);
       }
 

--- a/ui/src/websites/bluesky/Bluesky.tsx
+++ b/ui/src/websites/bluesky/Bluesky.tsx
@@ -67,7 +67,7 @@ BlueskyNotificationOptions
         <Select
           {...GenericSelectProps}
           className="w-full"
-          value={data.threadgate}
+          value={data.threadgate || ''}
           onChange={this.setValue.bind(this, 'threadgate')}
         >
           <Select.Option value={''}>Everybody</Select.Option>
@@ -106,7 +106,7 @@ export class BlueskyFileSubmissionForm extends GenericFileSubmissionSection<Blue
       <Select
         {...GenericSelectProps}
         className="w-full"
-        value={data.threadgate}
+        value={data.threadgate || ''}
         onChange={this.setValue.bind(this, 'threadgate')}
       >
         <Select.Option value={''}>Everybody</Select.Option>


### PR DESCRIPTION
It ended up being treated as a nonexistent option in the UI and as "nobody" in the posting code. Now it gets treated the same as an empty string, which is "everybody", as it ought to. Thanks ArgonVile for pointing this out.