### PR TITLE
Add no tags warning (BlueSky and Megalodon)

### DIFF
--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -476,6 +476,9 @@ export class Bluesky extends Website {
           this.MAX_CHARS,
           getRichTextLength,
         );
+      } else {
+        warnings.push(`You have not inserted the {tags} shortcut in your description; 
+          tags will not be inserted in your post`)
       }
     }
   }

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -227,12 +227,17 @@ export abstract class Megalodon extends Website {
         `Max description length allowed is ${instanceSettings.maxChars} characters.`,
       );
     } else {
-      this.validateInsertTags(
-        warnings,
-        this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
-        description,
-        instanceSettings.maxChars,
-      );
+      if (description.toLowerCase().indexOf('{tags}') > -1) {
+        this.validateInsertTags(
+          warnings,
+          this.formatTags(FormContent.getTags(defaultPart.data.tags, submissionPart.data.tags)),
+          description,
+          instanceSettings.maxChars,
+        );
+      } else {
+        warnings.push(`You have not inserted the {tags} shortcut in your description; 
+          tags will not be inserted in your post`)
+      }
     }
 
     const files = [


### PR DESCRIPTION
Add's a warning to validation if no {tags} shortcut is found in a file posting for these networks, given that is how they currently handle most of their discoverability (and it's currently catching people out)