### PR TITLE
Make content warnings part of the default section

### DIFF
--- a/commons/src/interfaces/submission/default-options.interface.ts
+++ b/commons/src/interfaces/submission/default-options.interface.ts
@@ -7,6 +7,7 @@ export interface DefaultOptions {
   tags: TagData;
   description: DescriptionData;
   rating?: SubmissionRating | string;
+  spoilerText?: string;
   sources: string[];
 }
 

--- a/commons/src/interfaces/websites/itaku/itaku.file.options.interface.ts
+++ b/commons/src/interfaces/websites/itaku/itaku.file.options.interface.ts
@@ -5,4 +5,5 @@ export interface ItakuFileOptions extends DefaultFileOptions {
   visibility: string;
   shareOnFeed: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
 }

--- a/commons/src/interfaces/websites/itaku/itaku.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/itaku/itaku.notification.options.interface.ts
@@ -4,4 +4,5 @@ export interface ItakuNotificationOptions extends DefaultOptions {
   folders: string[];
   visibility: string;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
 }

--- a/commons/src/interfaces/websites/mastodon/mastodon.file.options.interface.ts
+++ b/commons/src/interfaces/websites/mastodon/mastodon.file.options.interface.ts
@@ -3,6 +3,7 @@ import { DefaultFileOptions } from '../../submission/default-options.interface';
 export interface MastodonFileOptions extends DefaultFileOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
   altText?: string;
   replyToUrl?: string;

--- a/commons/src/interfaces/websites/mastodon/mastodon.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/mastodon/mastodon.notification.options.interface.ts
@@ -3,6 +3,7 @@ import { DefaultOptions } from '../../submission/default-options.interface';
 export interface MastodonNotificationOptions extends DefaultOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
   replyToUrl?: string;
 }

--- a/commons/src/interfaces/websites/misskey/misskey.file.options.interface.ts
+++ b/commons/src/interfaces/websites/misskey/misskey.file.options.interface.ts
@@ -3,6 +3,7 @@ import { DefaultFileOptions } from '../../submission/default-options.interface';
 export interface MissKeyFileOptions extends DefaultFileOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
   altText?: string;
 }

--- a/commons/src/interfaces/websites/misskey/misskey.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/misskey/misskey.notification.options.interface.ts
@@ -3,5 +3,6 @@ import { DefaultOptions } from '../../submission/default-options.interface';
 export interface MissKeyNotificationOptions extends DefaultOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
 }

--- a/commons/src/interfaces/websites/pixelfed/pixelfed.file.options.interface.ts
+++ b/commons/src/interfaces/websites/pixelfed/pixelfed.file.options.interface.ts
@@ -3,6 +3,7 @@ import { DefaultFileOptions } from '../../submission/default-options.interface';
 export interface PixelfedFileOptions extends DefaultFileOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
   altText?: string;
 }

--- a/commons/src/interfaces/websites/pleroma/pleroma.file.options.interface.ts
+++ b/commons/src/interfaces/websites/pleroma/pleroma.file.options.interface.ts
@@ -3,6 +3,7 @@ import { DefaultFileOptions } from '../../submission/default-options.interface';
 export interface PleromaFileOptions extends DefaultFileOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
   altText?: string;
   replyToUrl?: string;

--- a/commons/src/interfaces/websites/pleroma/pleroma.notification.options.interface.ts
+++ b/commons/src/interfaces/websites/pleroma/pleroma.notification.options.interface.ts
@@ -3,6 +3,7 @@ import { DefaultOptions } from '../../submission/default-options.interface';
 export interface PleromaNotificationOptions extends DefaultOptions {
   useTitle: boolean;
   spoilerText?: string;
+  spoilerTextOverwrite?: boolean;
   visibility: string;
   replyToUrl?: string;
 }

--- a/commons/src/models/default-options.entity.ts
+++ b/commons/src/models/default-options.entity.ts
@@ -30,6 +30,10 @@ export class DefaultOptionsEntity implements DefaultOptions {
   @IsOptional()
   rating?: SubmissionRating | string;
 
+  @Expose()
+  @IsOptional()
+  spoilerText?: string;
+
   @IsArray()
   sources: string[];
 

--- a/commons/src/websites/itaku/itaku.file.options.ts
+++ b/commons/src/websites/itaku/itaku.file.options.ts
@@ -26,6 +26,11 @@ export class ItakuFileOptionsEntity extends DefaultFileOptionsEntity implements 
   @IsOptional()
   spoilerText?: string;
 
+  @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
   constructor(entity?: Partial<ItakuFileOptions>) {
     super(entity as DefaultFileOptions);
   }

--- a/commons/src/websites/itaku/itaku.notification.options.ts
+++ b/commons/src/websites/itaku/itaku.notification.options.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsArray, IsString, IsOptional } from 'class-validator';
+import { IsArray, IsString, IsOptional, IsBoolean } from 'class-validator';
 import { DefaultOptions } from '../../interfaces/submission/default-options.interface';
 import { ItakuNotificationOptions } from '../../interfaces/websites/itaku/itaku.notification.options.interface';
 import { DefaultValue } from '../../models/decorators/default-value.decorator';
@@ -23,6 +23,11 @@ export class ItakuNotificationOptionsEntity
   @IsString()
   @IsOptional()
   spoilerText?: string;
+
+  @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
 
   constructor(entity?: Partial<ItakuNotificationOptions>) {
     super(entity as DefaultOptions);

--- a/commons/src/websites/mastodon/mastodon.file.options.ts
+++ b/commons/src/websites/mastodon/mastodon.file.options.ts
@@ -20,6 +20,11 @@ export class MastodonFileOptionsEntity
   spoilerText?: string;
 
   @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
+  @Expose()
   @IsString()
   @DefaultValue('public')
   visibility!: string;

--- a/commons/src/websites/mastodon/mastodon.notification.options.ts
+++ b/commons/src/websites/mastodon/mastodon.notification.options.ts
@@ -20,6 +20,11 @@ export class MastodonNotificationOptionsEntity
   spoilerText?: string;
 
   @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
+  @Expose()
   @IsString()
   @DefaultValue('public')
   visibility!: string;

--- a/commons/src/websites/misskey/misskey.file.options.ts
+++ b/commons/src/websites/misskey/misskey.file.options.ts
@@ -20,6 +20,11 @@ export class MissKeyFileOptionsEntity
   spoilerText?: string;
 
   @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
+  @Expose()
   @IsString()
   @DefaultValue('public')
   visibility!: string;

--- a/commons/src/websites/misskey/misskey.notification.options.ts
+++ b/commons/src/websites/misskey/misskey.notification.options.ts
@@ -20,6 +20,11 @@ export class MissKeyNotificationOptionsEntity
   spoilerText?: string;
 
   @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
+  @Expose()
   @IsString()
   @DefaultValue('public')
   visibility!: string;

--- a/commons/src/websites/pixelfed/pixelfed.file.options.ts
+++ b/commons/src/websites/pixelfed/pixelfed.file.options.ts
@@ -20,6 +20,11 @@ export class PixelfedFileOptionsEntity
   spoilerText?: string;
 
   @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
+  @Expose()
   @IsString()
   @DefaultValue('public')
   visibility!: string;

--- a/commons/src/websites/pleroma/pleroma.file.options.ts
+++ b/commons/src/websites/pleroma/pleroma.file.options.ts
@@ -16,7 +16,12 @@ export class PleromaFileOptionsEntity extends DefaultFileOptionsEntity
   @IsOptional()
   @IsString()
   spoilerText?: string;
-  
+
+  @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
   @Expose()
   @IsString()
   @DefaultValue('public')

--- a/commons/src/websites/pleroma/pleroma.notification.options.ts
+++ b/commons/src/websites/pleroma/pleroma.notification.options.ts
@@ -18,6 +18,11 @@ export class PleromaNotificationOptionsEntity extends DefaultOptionsEntity
   spoilerText?: string;
 
   @Expose()
+  @IsBoolean()
+  @IsOptional()
+  spoilerTextOverwrite?: boolean;
+
+  @Expose()
   @IsString()
   @DefaultValue('public')
   visibility!: string;

--- a/electron-app/src/server/submission/parser/parser.service.ts
+++ b/electron-app/src/server/submission/parser/parser.service.ts
@@ -68,6 +68,7 @@ export class ParserService {
       submission,
       tags,
       title: this.getTitle(submission, defaultPart, websitePart),
+      spoilerText: this.getSpoilerText(defaultPart, websitePart),
     };
 
     if (this.isFileSubmission(submission)) {
@@ -125,6 +126,22 @@ export class ParserService {
     websitePart: SubmissionPartEntity<any>,
   ): string {
     return (websitePart.data.title || defaultPart.data.title || submission.title).substring(0, 160);
+  }
+
+  private getSpoilerText(
+    defaultPart: SubmissionPartEntity<DefaultOptions>,
+    websitePart: SubmissionPartEntity<any>,
+  ): string {
+    const overwrite = websitePart.data.spoilerTextOverwrite;
+    const defaultSpoilerText = defaultPart.data.spoilerText || '';
+    const websiteSpoilerText = `${websitePart.data.spoilerText || ''}`;
+    if (overwrite === undefined) {
+      return websiteSpoilerText.trim() === '' ? defaultSpoilerText : websiteSpoilerText;
+    } else if (overwrite) {
+      return websiteSpoilerText;
+    } else {
+      return defaultSpoilerText;
+    }
   }
 
   private isFileSubmission(submission: Submission): submission is FileSubmission {

--- a/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
+++ b/electron-app/src/server/submission/parser/section-parsers/description.parser.ts
@@ -53,7 +53,7 @@ export class DescriptionParser {
     ).trim();
 
     if (description.length) {
-      // Insert {default}, {title}, {tags} shortcuts
+      // Insert {default}, {title}, {tags}, {cw} shortcuts
       let tags = await this.parserService.parseTags(website, defaultPart, websitePart);
       description = this.insertDefaultShortcuts(description, [
         {
@@ -67,6 +67,10 @@ export class DescriptionParser {
         {
           name: 'tags',
           content: website.generateTagsString(tags, description, websitePart),
+        },
+        {
+          name: 'cw',
+          content: FormContent.getSpoilerText(defaultPart.data, websitePart.data),
         },
       ]);
 

--- a/electron-app/src/server/submission/post/interfaces/post-data.interface.ts
+++ b/electron-app/src/server/submission/post/interfaces/post-data.interface.ts
@@ -11,4 +11,5 @@ export interface PostData<T extends Submission, K extends DefaultOptions> {
   submission: T;
   tags: string[];
   title: string;
+  spoilerText: string;
 }

--- a/electron-app/src/server/utils/form-content.util.ts
+++ b/electron-app/src/server/utils/form-content.util.ts
@@ -20,4 +20,20 @@ export default class FormContent {
       ? _.get(websiteDescription, 'value', '')
       : _.get(defaultDescription, 'value', '');
   }
+
+  static getSpoilerText(
+    defaultData: { spoilerText?: string },
+    partData: { spoilerText?: string; spoilerTextOverwrite?: boolean },
+  ): string {
+    const partSpoilerText = partData.spoilerText || '';
+    const overwrite =
+      partData.spoilerTextOverwrite === undefined
+        ? partSpoilerText.trim() !== ''
+        : partData.spoilerTextOverwrite;
+    if (overwrite) {
+      return partSpoilerText;
+    } else {
+      return defaultData.spoilerText || '';
+    }
+  }
 }

--- a/electron-app/src/server/websites/itaku/itaku.service.ts
+++ b/electron-app/src/server/websites/itaku/itaku.service.ts
@@ -174,8 +174,8 @@ export class Itaku extends Website {
       postData.add_to_feed = 'true';
     }
 
-    if (data.options.spoilerText) {
-      postData.content_warning = data.options.spoilerText;
+    if (data.spoilerText) {
+      postData.content_warning = data.spoilerText;
     }
 
     if (fileRecord.type === FileSubmissionType.IMAGE) {
@@ -256,7 +256,7 @@ export class Itaku extends Website {
 
   validateFileSubmission(
     submission: FileSubmission,
-    submissionPart: SubmissionPart<any>,
+    submissionPart: SubmissionPart<ItakuFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
   ): ValidationParts {
     const problems: string[] = [];
@@ -290,6 +290,11 @@ export class Itaku extends Website {
 
     if (submission.additional?.length && !submissionPart.data.shareOnFeed) {
       problems.push(`Posting multiple images requires share on feed to be enabled`);
+    }
+
+    const spoilerText = FormContent.getSpoilerText(defaultPart.data, submissionPart.data);
+    if (spoilerText.length > 30) {
+      problems.push(`Max content warning length allowed is 30 characters`);
     }
 
     return { problems, warnings };

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -142,8 +142,8 @@ export abstract class Megalodon extends Website {
         statusOptions.in_reply_to_id = replyToId;
       }
 
-      if (data.options.spoilerText) {
-        statusOptions.spoiler_text = data.options.spoilerText;
+      if (data.spoilerText) {
+        statusOptions.spoiler_text = data.spoilerText;
       }
 
       // Mastodon may return a 422 error if the media is still processing,
@@ -200,8 +200,8 @@ export abstract class Megalodon extends Website {
     let status = `${data.options.useTitle && data.title ? `${data.title}\n` : ''}${
       data.description
     }`;
-    if (data.options.spoilerText) {
-      statusOptions.spoiler_text = data.options.spoilerText;
+    if (data.spoilerText) {
+      statusOptions.spoiler_text = data.spoilerText;
     }
 
     const replyToId = this.getPostIdFromUrl(data.options.replyToUrl);

--- a/electron-app/src/server/websites/misskey/misskey.service.ts
+++ b/electron-app/src/server/websites/misskey/misskey.service.ts
@@ -155,8 +155,8 @@ export class MissKey extends Website {
       if (i !== 0) {
         statusOptions.in_reply_to_id = lastId;
       }
-      if (data.options.spoilerText) {
-        statusOptions.spoiler_text = data.options.spoilerText;
+      if (data.spoilerText) {
+        statusOptions.spoiler_text = data.spoilerText;
       }
 
       this.checkCancelled(cancellationToken);
@@ -196,8 +196,8 @@ export class MissKey extends Website {
     let status = `${data.options.useTitle && data.title ? `${data.title}\n` : ''}${
       data.description
     }`.substring(0, maxChars);
-    if (data.options.spoilerText) {
-      statusOptions.spoiler_text = data.options.spoilerText;
+    if (data.spoilerText) {
+      statusOptions.spoiler_text = data.spoilerText;
     }
 
     this.checkCancelled(cancellationToken);

--- a/ui/src/views/submissions/submission-forms/form-components/DescriptionInput.tsx
+++ b/ui/src/views/submissions/submission-forms/form-components/DescriptionInput.tsx
@@ -181,6 +181,13 @@ export default class DescriptionInput extends React.Component<Props, State> {
                           Inserts the website tags or the default tags separated by ' #'
                         </span>
                       </li>
+                      <li>
+                        <code>{'{cw}'}</code>
+                        <span className="mx-1">-</span>
+                        <span>
+                          Inserts the content warning
+                        </span>
+                      </li>
                     </ul>
                   </div>
                 }

--- a/ui/src/views/submissions/submission-forms/form-components/SpoilerTextInput.tsx
+++ b/ui/src/views/submissions/submission-forms/form-components/SpoilerTextInput.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Form, Input, Switch } from 'antd';
+import { observer } from 'mobx-react';
+
+interface Props {
+  label?: string;
+  maxLength?: number;
+  overwriteDefault?: boolean;
+  spoilerText?: string;
+  onChangeOverwriteDefault: (overwriteDefault: boolean) => void;
+  onChangeSpoilerText: (spoilerText: string) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface State {}
+
+@observer
+export default class SpoilerTextInput extends React.Component<Props, State> {
+  state: State = {};
+
+  private overwriteDefault: boolean;
+  private spoilerText: string;
+
+  constructor(props: Props) {
+    super(props);
+    if (props.overwriteDefault === undefined) {
+      this.spoilerText = props.spoilerText || '';
+      this.overwriteDefault = this.spoilerText.trim() !== '';
+      if (this.overwriteDefault) {
+        this.props.onChangeOverwriteDefault(true);
+      }
+    } else {
+      this.overwriteDefault = !!props.overwriteDefault;
+      this.spoilerText = props.spoilerText || '';
+    }
+  }
+
+  handleOverwriteDefaultChange = (checked: boolean) => {
+    this.overwriteDefault = !checked;
+    this.props.onChangeOverwriteDefault(this.overwriteDefault);
+    if (!checked && this.props.overwriteDefault) {
+      this.handleSpoilerTextChange(this.props.spoilerText || '');
+    }
+  };
+
+  handleSpoilerTextChange = (spoilerText: string) => {
+    this.spoilerText = spoilerText;
+    this.props.onChangeSpoilerText(this.spoilerText);
+  };
+
+  render() {
+    return (
+      <Form.Item label={this.props.label || 'Content Warning'}>
+        <div>
+          <span className="mr-2">
+            <Switch
+              size="small"
+              checked={!this.props.overwriteDefault}
+              onChange={this.handleOverwriteDefaultChange}
+            />
+          </span>
+          <span>Use default</span>
+        </div>
+        {this.props.overwriteDefault && (
+          <Input
+            value={this.props.spoilerText}
+            onChange={e => this.handleSpoilerTextChange(e.target.value)}
+            maxLength={this.props.maxLength}
+          />
+        )}
+      </Form.Item>
+    );
+  }
+}

--- a/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
+++ b/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
@@ -62,6 +62,9 @@ export default class DefaultFormSection extends React.Component<
             <Radio.Button value={SubmissionRating.EXTREME}>Extreme</Radio.Button>
           </Radio.Group>
         </Form.Item>
+        <Form.Item label="Content Warning">
+          <Input value={data.spoilerText} onChange={this.handleChange.bind(this, 'spoilerText')} />
+        </Form.Item>
         <TagInput
           onChange={this.handleTagChange.bind(this)}
           defaultValue={data.tags}

--- a/ui/src/websites/itaku/Itaku.tsx
+++ b/ui/src/websites/itaku/Itaku.tsx
@@ -14,6 +14,7 @@ import GenericFileSubmissionSection from '../generic/GenericFileSubmissionSectio
 import { GenericSelectProps } from '../generic/GenericSelectProps';
 import GenericSubmissionSection from '../generic/GenericSubmissionSection';
 import { WebsiteImpl } from '../website.base';
+import SpoilerTextInput from '../../views/submissions/submission-forms/form-components/SpoilerTextInput';
 
 export class Itaku extends WebsiteImpl {
   internalName: string = 'Itaku';
@@ -214,13 +215,13 @@ export class ItakuFileSubmissionForm extends GenericFileSubmissionSection<ItakuF
           Share on feed
         </Checkbox>
       </div>,
-      <Form.Item label="Content Warning">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-          maxLength={30}
-        />
-      </Form.Item>
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+        maxLength={30}
+      ></SpoilerTextInput>,
     );
     return elements;
   }

--- a/ui/src/websites/mastodon/Mastodon.tsx
+++ b/ui/src/websites/mastodon/Mastodon.tsx
@@ -14,6 +14,7 @@ import GenericSubmissionSection from '../generic/GenericSubmissionSection';
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { WebsiteImpl } from '../website.base';
 import MastodonLogin from './MastodonLogin';
+import SpoilerTextInput from '../../views/submissions/submission-forms/form-components/SpoilerTextInput';
 
 export class Mastodon extends WebsiteImpl {
   internalName: string = 'Mastodon';
@@ -72,12 +73,12 @@ class MastodonNotificationSubmissionForm extends GenericSubmissionSection<
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Post Visibility">
         <Select
           {...GenericSelectProps}
@@ -111,12 +112,12 @@ export class MastodonFileSubmissionForm extends GenericFileSubmissionSection<Mas
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}

--- a/ui/src/websites/misskey/MissKey.tsx
+++ b/ui/src/websites/misskey/MissKey.tsx
@@ -14,6 +14,7 @@ import GenericSubmissionSection from '../generic/GenericSubmissionSection';
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { WebsiteImpl } from '../website.base';
 import MissKeyLogin from './MissKeyLogin';
+import SpoilerTextInput from '../../views/submissions/submission-forms/form-components/SpoilerTextInput';
 
 export class MissKey extends WebsiteImpl {
   internalName: string = 'MissKey';
@@ -72,12 +73,12 @@ class MissKeyNotificationSubmissionForm extends GenericSubmissionSection<
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Post Visibility">
         <Select
           {...GenericSelectProps}
@@ -108,12 +109,12 @@ export class MissKeyFileSubmissionForm extends GenericFileSubmissionSection<Miss
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}

--- a/ui/src/websites/pixelfed/Pixelfed.tsx
+++ b/ui/src/websites/pixelfed/Pixelfed.tsx
@@ -13,6 +13,7 @@ import GenericSubmissionSection from '../generic/GenericSubmissionSection';
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { WebsiteImpl } from '../website.base';
 import PixelfedLogin from './PixelfedLogin';
+import SpoilerTextInput from '../../views/submissions/submission-forms/form-components/SpoilerTextInput';
 
 export class Pixelfed extends WebsiteImpl {
   internalName: string = 'Pixelfed';
@@ -52,12 +53,12 @@ export class PixelfedFileSubmissionForm extends GenericFileSubmissionSection<Pix
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Fallback Alt Text">
         <Input
           value={data.altText}

--- a/ui/src/websites/pleroma/Pleroma.tsx
+++ b/ui/src/websites/pleroma/Pleroma.tsx
@@ -14,6 +14,7 @@ import GenericSubmissionSection from '../generic/GenericSubmissionSection';
 import { LoginDialogProps } from '../interfaces/website.interface';
 import { WebsiteImpl } from '../website.base';
 import PleromaLogin from './PleromaLogin';
+import SpoilerTextInput from '../../views/submissions/submission-forms/form-components/SpoilerTextInput';
 
 export class Pleroma extends WebsiteImpl {
   internalName: string = 'Pleroma';
@@ -71,12 +72,12 @@ class PleromaNotificationSubmissionForm extends GenericSubmissionSection<
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Post Visibility">
         <Select
           {...GenericSelectProps}
@@ -110,12 +111,12 @@ export class PleromaFileSubmissionForm extends GenericFileSubmissionSection<Pler
           Use title
         </Checkbox>
       </div>,
-      <Form.Item label="Spoiler Text">
-        <Input
-          value={data.spoilerText}
-          onChange={this.handleValueChange.bind(this, 'spoilerText')}
-        />
-      </Form.Item>,
+      <SpoilerTextInput
+        overwriteDefault={data.spoilerTextOverwrite}
+        spoilerText={data.spoilerText}
+        onChangeOverwriteDefault={this.setValue.bind(this, 'spoilerTextOverwrite')}
+        onChangeSpoilerText={this.setValue.bind(this, 'spoilerText')}
+      ></SpoilerTextInput>,
       <Form.Item label="Alt Text">
         <Input
           value={data.altText}


### PR DESCRIPTION
Because I'm getting tired of repeating it for a bunch of sites.

The content warning will automatically be applied to Itaku, Mastodon, Misskey, Pixelfed and Pleroma. They can also overwrite the default via toggle switch, similar to how it works for descriptions. Probably mostly necessary for Itaku with its dinky 30 character limit.

The content warning can be included into the description using the {cw} shortcut. This is mostly useful for sites like Bluesky and Telegram, which support spoilers, but don't have a dedicated content warning field.

Backward compatibility with existing posts should be preserved: if the overwrite option is undefined, it will be guessed by the presence of a non-empty content warning text.

This also now consistently presents the field as "content warning" to the user, rather than revealing the internal "spoiler text" name. I've seen confused users on Mastodon thinking that PostyBirb didn't support content warnings because of the misnomer.