### PR TITLE
Fix Ko-Fi post status parsing, Furry-Network error inspection

### DIFF
--- a/electron-app/src/server/utils/browser-window.util.spec.ts
+++ b/electron-app/src/server/utils/browser-window.util.spec.ts
@@ -1,0 +1,55 @@
+import { error } from 'console';
+import BrowserWindowUtil from './browser-window.util';
+import express from 'express';
+
+const partitionId = 'TESTING_PARTITION';
+
+// Setup local server so we not depends on network
+let url = '';
+beforeAll(done => {
+  const app = express();
+  app.get('/', (req, res) =>
+    res.send(`
+    <!DOCTYPE html>
+    <html lang="en">
+      <head></head>
+      <body></body>
+    </html>`),
+  );
+
+  const port = 52243;
+  app.listen(port, () => {
+    url = `http://localhost:${port}/`;
+    done();
+  });
+});
+
+describe('BrowserWindowUtil', () => {
+  it('should return status and code', async () => {
+    expect(
+      await BrowserWindowUtil.runScriptOnPage(
+        partitionId,
+        url,
+        `var a = { code: 200, status: true };
+         return a`,
+      ),
+    ).toEqual({
+      code: 200,
+      status: true,
+    });
+  });
+
+  it('should throw informative error', async () => {
+    const fn = `throwsError`;
+    const script = `${fn}()`;
+    const error = `${fn} is not defined`;
+
+    try {
+      await BrowserWindowUtil.runScriptOnPage(partitionId, url, script);
+      fail('no error was thrown!');
+    } catch (e) {
+      expect(e.message).toEqual(`Failed to run script on page: ${error}\n\nscript:\n${script}\n`);
+      expect(e.stack).toEqual(`Error: ${error}`);
+    }
+  });
+});

--- a/electron-app/src/server/websites/furry-network/furry-network.service.ts
+++ b/electron-app/src/server/websites/furry-network/furry-network.service.ts
@@ -225,9 +225,17 @@ export class FurryNetwork extends Website {
       responses.push(create);
     }
 
-    const res = JSON.parse(responses.find(r => r.body).body ?? '{}');
+    const { body } = responses.find(r => r.body);
+    if (body.startsWith('<')) {
+      throw this.createPostResponse({
+        error: 'HTML response instead of json, check logs for additional info',
+        additionalInfo: body,
+      });
+    }
+
+    const res = JSON.parse(body || '{}');
     if (!res || !res.id) {
-      throw this.createPostResponse({ additionalInfo: res });
+      throw this.createPostResponse({ error: 'unexpected response type.', additionalInfo: res });
     }
     return res;
   }

--- a/electron-app/src/server/websites/furry-network/furry-network.service.ts
+++ b/electron-app/src/server/websites/furry-network/furry-network.service.ts
@@ -216,7 +216,7 @@ export class FurryNetwork extends Website {
       xhr.setRequestHeader("Content-Type", "binary/octet-stream, application/json");
       xhr.send(blob);
       var body = xhr.response;
-      Object.assign({}, { body: body, status: xhr.status })`;
+      return Object.assign({}, { body: body, status: xhr.status })`;
       const create = await BrowserWindowUtil.runScriptOnPage<{ body: string; status: number }>(
         profileId,
         `${this.BASE_URL}`,
@@ -272,7 +272,7 @@ export class FurryNetwork extends Website {
       xhr.setRequestHeader("Content-Type", "binary/octet-stream, application/json");
       xhr.send(blob);
       var body = xhr.response;
-      Object.assign({}, { body: body, status: xhr.status })`;
+      return Object.assign({}, { body: body, status: xhr.status })`;
     return await BrowserWindowUtil.runScriptOnPage<{ body: string; status: number }>(
       profileId,
       `${this.BASE_URL}`,
@@ -289,7 +289,7 @@ export class FurryNetwork extends Website {
       xhr.setRequestHeader("Content-Type", "application/json");
       xhr.send(JSON.stringify(data));
       var body = xhr.response;
-      Object.assign({}, { body: body, status: xhr.status })`;
+      return Object.assign({}, { body: body, status: xhr.status })`;
     return await BrowserWindowUtil.runScriptOnPage<{ body: string; status: number }>(
       profileId,
       `${this.BASE_URL}`,

--- a/electron-app/src/server/websites/newgrounds/newgrounds.service.ts
+++ b/electron-app/src/server/websites/newgrounds/newgrounds.service.ts
@@ -185,7 +185,7 @@ export class Newgrounds extends Website {
     const userKey: string = await BrowserWindowUtil.runScriptOnPage(
       data.part.accountId,
       `${this.BASE_URL}/projects/art/new`,
-      'PHP.get("uek")',
+      'return PHP.get("uek")',
       300,
     );
     if (!userKey) {

--- a/electron-app/src/server/websites/patreon/patreon.service.ts
+++ b/electron-app/src/server/websites/patreon/patreon.service.ts
@@ -86,7 +86,7 @@ export class Patreon extends Website {
         relationships: any;
         type: string;
       }[];
-    }>(data._id, `${this.BASE_URL}/membership`, 'window.patreon.bootstrap.creator', 1000);
+    }>(data._id, `${this.BASE_URL}/membership`, 'return window.patreon.bootstrap.creator', 1000);
 
     if (body.data) {
       status.loggedIn = true;
@@ -153,7 +153,7 @@ export class Patreon extends Website {
     const csrf = await BrowserWindowUtil.runScriptOnPage<string>(
       profileId,
       `${this.BASE_URL}`,
-      'window.__NEXT_DATA__.props.pageProps.bootstrapEnvelope.csrfSignature',
+      'return window.__NEXT_DATA__.props.pageProps.bootstrapEnvelope.csrfSignature',
       100,
     );
     if (!csrf) {
@@ -228,7 +228,7 @@ export class Patreon extends Website {
     xhr.setRequestHeader("Content-Type", "application/vnd.api+json");
     xhr.send(JSON.stringify(data));
     var body = xhr.response;
-    Object.assign({}, { body: body, status: xhr.status })`;
+    return Object.assign({}, { body: body, status: xhr.status })`;
     const create = await BrowserWindowUtil.runScriptOnPage<{ body: string; status: number }>(
       profileId,
       `${this.BASE_URL}`,
@@ -252,7 +252,7 @@ export class Patreon extends Website {
     xhr.setRequestHeader("Content-Type", "application/vnd.api+json");
     xhr.send(JSON.stringify(data));
     var body = xhr.response;
-    Object.assign({}, { body: body, status: xhr.status })`;
+    return Object.assign({}, { body: body, status: xhr.status })`;
     return BrowserWindowUtil.runScriptOnPage<{ body: string; status: number }>(
       profileId,
       `${this.BASE_URL}/posts/${id}/edit`,
@@ -581,7 +581,7 @@ export class Patreon extends Website {
     var xhr = new XMLHttpRequest();
     xhr.open('POST', dest, false);
     xhr.send(fd);
-    Object.assign({}, { body: body, status: xhr.status, response: xhr.response })`;
+    return Object.assign({}, { body: body, status: xhr.status, response: xhr.response })`;
     const upload = await BrowserWindowUtil.runScriptOnPage<{
       body: any;
       status: number;
@@ -619,7 +619,7 @@ export class Patreon extends Website {
     xhr.open('POST', '/api/posts/${link}/attachments?json-api-version=1.0', false);
     xhr.setRequestHeader("X-CSRF-Signature", "${csrf}");
     xhr.send(fd);
-    xhr.status`;
+    return xhr.status`;
 
     const upload = await BrowserWindowUtil.runScriptOnPage<number>(
       profileId,

--- a/electron-app/src/server/websites/subscribe-star-adult/subscribe-star-adult.service.ts
+++ b/electron-app/src/server/websites/subscribe-star-adult/subscribe-star-adult.service.ts
@@ -132,7 +132,7 @@ export class SubscribeStarAdult extends Website {
     xhr.open('POST', '/posts.json', false);
     xhr.setRequestHeader("X-CSRF-Token", document.body.parentElement.innerHTML.match(/<meta name="csrf-token" content="(.*?)"/)[1]);
     xhr.send(fd);
-    xhr.responseText
+    return xhr.responseText
     `;
 
     const upload = await BrowserWindowUtil.runScriptOnPage<string>(
@@ -167,7 +167,7 @@ export class SubscribeStarAdult extends Website {
     xhr.open('POST', '${url}', false);
     xhr.setRequestHeader("X-CSRF-Token", document.body.parentElement.innerHTML.match(/<meta name="csrf-token" content="(.*?)"/)[1]);
     xhr.send(fd);
-    xhr.responseText
+    return xhr.responseText
     `;
 
     const upload = await BrowserWindowUtil.runScriptOnPage<string>(
@@ -250,7 +250,7 @@ export class SubscribeStarAdult extends Website {
         return out;
       }
       
-      getInfo();
+      return getInfo();
     `,
     );
 

--- a/electron-app/src/server/websites/subscribe-star/subscribe-star.service.ts
+++ b/electron-app/src/server/websites/subscribe-star/subscribe-star.service.ts
@@ -120,7 +120,7 @@ export class SubscribeStar extends Website {
     xhr.open('POST', '/posts.json', false);
     xhr.setRequestHeader("X-CSRF-Token", document.body.parentElement.innerHTML.match(/<meta name="csrf-token" content="(.*?)"/)[1]);
     xhr.send(fd);
-    xhr.responseText
+    return xhr.responseText
     `;
 
     const upload = await BrowserWindowUtil.runScriptOnPage<string>(
@@ -155,7 +155,7 @@ export class SubscribeStar extends Website {
     xhr.open('POST', '${url}', false);
     xhr.setRequestHeader("X-CSRF-Token", document.body.parentElement.innerHTML.match(/<meta name="csrf-token" content="(.*?)"/)[1]);
     xhr.send(fd);
-    xhr.responseText
+    return xhr.responseText
     `;
 
     const upload = await BrowserWindowUtil.runScriptOnPage<string>(
@@ -238,7 +238,7 @@ export class SubscribeStar extends Website {
         return out;
       }
       
-      getInfo();
+      return getInfo();
     `,
     );
 

--- a/electron-app/src/server/websites/telegram/telegram.service.ts
+++ b/electron-app/src/server/websites/telegram/telegram.service.ts
@@ -273,7 +273,7 @@ export class Telegram extends Website {
       offset_peer: {
         _: 'inputPeerEmpty',
       },
-      limit: 100,
+      limit: 200,
     });
 
     const channels: Folder[] = chats
@@ -526,7 +526,7 @@ export class Telegram extends Website {
       );
       submissionPart.data.channels.forEach(f => {
         if (!WebsiteValidator.folderIdExists(f, folders)) {
-          problems.push(`Channel (${f}) not found.`);
+          problems.push(this.channelNotFound(f));
         }
       });
     } else {
@@ -564,7 +564,7 @@ export class Telegram extends Website {
 
       if (FileSize.MBtoBytes(10) < size && type !== FileSubmissionType.IMAGE) {
         warnings.push(
-          `${name} will show in channel as Unknown Track but still will be available.`,
+          `${name} will show in channel as Unknown Track but still will be available to download.`,
         );
       }
     });
@@ -588,7 +588,9 @@ export class Telegram extends Website {
       );
       submissionPart.data.channels.forEach(f => {
         if (!WebsiteValidator.folderIdExists(f, folders)) {
-          problems.push(`Channel (${f}) not found.`);
+          problems.push(
+            this.channelNotFound(f),
+          );
         }
       });
     } else {
@@ -604,6 +606,10 @@ export class Telegram extends Website {
     }
 
     return { problems, warnings };
+  }
+
+  private channelNotFound(f: string) {
+    return `Channel (${f}) not found. PostyBirb requests latest 200 chats and then filters them to include only those where you can send medias. If you have a lot of active chats you will not see inactive channels. To fix this, simply post something in the channel.`;
   }
 }
 

--- a/electron-app/src/server/websites/telegram/telegram.service.ts
+++ b/electron-app/src/server/websites/telegram/telegram.service.ts
@@ -609,7 +609,7 @@ export class Telegram extends Website {
   }
 
   private channelNotFound(f: string) {
-    return `Channel (${f}) not found. PostyBirb requests latest 200 chats and then filters them to include only those where you can send medias. If you have a lot of active chats you will not see inactive channels. To fix this, simply post something in the channel.`;
+    return `Channel (${f}) not found. To fix this, simply post something in the channel. PostyBirb requests latest 200 chats and then filters them to include only those where you can send media. If you have a lot of active chats, PostyBirb will be not able to view inactive channels.`;
   }
 }
 


### PR DESCRIPTION
For some reason Ko-Fi post.body can be \u0000\u0007\u0000{"success":true}\u0003
Report: https://discord.com/channels/395931304870281216/580751000835588156/1216467099975942334

Fixes BrowserWindowUtil.runScriptOnPage error handling to be more informative instead of just `Script failed to execute`
Report: https://discord.com/channels/395931304870281216/580751000835588156/1217943590718799962