### PR TITLE
fix: Stop escaping Twitter usernames.

### DIFF
--- a/electron-app/src/server/websites/twitter/twitter-api.service.ts
+++ b/electron-app/src/server/websites/twitter/twitter-api.service.ts
@@ -110,7 +110,7 @@ export class TwitterAPIService {
       // possibly_sensitive: data.rating !== 'general',
     };
 
-    tweet.text = (tweet?.text || '').replace(/@(\w+)/g, '@/$1');
+    tweet.text = (tweet?.text || '');
 
     let mediaIds = [];
     if (data.files.length) {


### PR DESCRIPTION
This pull request removes the escape mechanism from Twitter posts when tagging usernames. This feature was initially added to reduce the likelihood of PostyBirb's API keys getting banned. However, now that each individual user generates their own API keys, each individual is responsible for their own use of the API and one getting banned does not affect other users.

**Testing instructions**:

1. Create a new post on Twitter which mentions another user.
2. Verify the person is properly mentioned as expected.