### PR TITLE
fix: Update Artconomy post limit

### DIFF
--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -260,7 +260,7 @@ export class Artconomy extends Website {
       problems.push('Description must be 2000 characters or fewer.')
     }
 
-    const maxMB = 99;
+    const maxMB = 49;
     files.forEach(file => {
       const { type, size, name, mimetype } = file;
       if (!WebsiteValidator.supportsFileType(file, this.acceptsFiles)) {


### PR DESCRIPTION
Artconomy has updated its maximum size limit from 100MB down to 50MB. This PR changes the code to reflect this. Note that the supported size is internally marked as slightly smaller to account for overhead, since the limit is at the request size level.

**Testing instructions**:

1. Attempt to upload a file that's too large.
2. Verify it is either auto-resized or fails if the file cannot be resized by PostyBirb.