### PR TITLE
Resize Picarto to max 4k

### DIFF
--- a/electron-app/src/server/websites/picarto/picarto.service.ts
+++ b/electron-app/src/server/websites/picarto/picarto.service.ts
@@ -100,7 +100,12 @@ export class Picarto extends Website {
   }
 
   getScalingOptions(file: FileRecord): ScalingOptions {
-    return { maxSize: FileSize.MBtoBytes(15) };
+    // Max 4K image size for non member users
+    return { 
+      maxHeight: 3840, 
+      maxWidth: 2160,
+      maxSize: FileSize.MBtoBytes(15) 
+    };
   }
 
   private getRating(rating: SubmissionRating): string {


### PR DESCRIPTION
As discussed on Discord, non-members on Picarto are capped at 4k size.