### PR TITLE
Fix description length validation and tag limiting

### DIFF
--- a/electron-app/src/server/submission/parser/parser.service.ts
+++ b/electron-app/src/server/submission/parser/parser.service.ts
@@ -14,6 +14,7 @@ import {
   Submission,
   FileSubmission,
   FileRecord,
+  SubmissionPart,
 } from 'postybirb-commons';
 import { ScalingOptions } from 'src/server/websites/interfaces/scaling-options.interface';
 import { PostData } from '../post/interfaces/post-data.interface';
@@ -42,7 +43,12 @@ export class ParserService {
     private readonly fileManipulator: FileManipulationService,
     websitesService: WebsitesService,
   ) {
-    this.descriptionParser = new DescriptionParser(customShortcuts, websitesService, settings, this);
+    this.descriptionParser = new DescriptionParser(
+      customShortcuts,
+      websitesService,
+      settings,
+      this,
+    );
   }
 
   public async parse(
@@ -86,17 +92,18 @@ export class ParserService {
 
   public async parseDescription(
     website: Website,
-    defaultPart: SubmissionPartEntity<DefaultOptions>,
-    websitePart: SubmissionPartEntity<DefaultOptions>,
+    defaultPart: SubmissionPart<DefaultOptions>,
+    websitePart: SubmissionPart<DefaultOptions>,
     type: SubmissionType,
+    generateTags: boolean = true,
   ): Promise<string> {
-    return this.descriptionParser.parse(website, defaultPart, websitePart, type);
+    return this.descriptionParser.parse(website, defaultPart, websitePart, type, generateTags);
   }
 
   public async parseTags(
     website: Website,
-    defaultPart: SubmissionPartEntity<DefaultOptions>,
-    websitePart: SubmissionPartEntity<DefaultOptions>,
+    defaultPart: SubmissionPart<DefaultOptions>,
+    websitePart: SubmissionPart<DefaultOptions>,
   ): Promise<string[]> {
     let tags = _.uniq<string>(FormContent.getTags(defaultPart.data.tags, websitePart.data.tags));
     if (tags.length) {

--- a/electron-app/src/server/submission/submission.service.ts
+++ b/electron-app/src/server/submission/submission.service.ts
@@ -477,7 +477,7 @@ export class SubmissionService {
     let hasProblems: boolean = false;
     const parts = await this.partService.getPartsForSubmission(submission._id, true);
     const problems: Problems = parts.length
-      ? this.validatorService.validateParts(submission, parts)
+      ? await this.validatorService.validateParts(submission, parts)
       : {};
     for (const p of Object.values(problems)) {
       if (p.problems.length) {

--- a/electron-app/src/server/submission/validator/validator.module.ts
+++ b/electron-app/src/server/submission/validator/validator.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ValidatorService } from './validator.service';
 import { WebsitesModule } from 'src/server/websites/websites.module';
+import { ParserModule } from '../parser/parser.module';
 
 @Module({
-  imports: [WebsitesModule],
+  imports: [WebsitesModule, ParserModule],
   providers: [ValidatorService],
   exports: [ValidatorService],
 })

--- a/electron-app/src/server/websites/artconomy/artconomy.service.ts
+++ b/electron-app/src/server/websites/artconomy/artconomy.service.ts
@@ -225,6 +225,7 @@ export class Artconomy extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<ArtconomyFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -252,11 +253,8 @@ export class Artconomy extends Website {
           'relationships depicted',
       );
     }
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    )
 
-    if (description.length > this.MAX_CHARS) {
+    if (this.stripTagsShortcut(description).length > this.MAX_CHARS) {
       problems.push('Description must be 2000 characters or fewer.')
     }
 

--- a/electron-app/src/server/websites/aryion/aryion.service.ts
+++ b/electron-app/src/server/websites/aryion/aryion.service.ts
@@ -163,6 +163,7 @@ export class Aryion extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<AryionFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -384,6 +384,7 @@ export class Bluesky extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<BlueskyFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -404,7 +405,7 @@ export class Bluesky extends Website {
 
     this.validateRating(submissionPart, defaultPart, warnings);
 
-    this.validateDescription(problems, warnings, submissionPart, defaultPart);
+    this.validateDescription(problems, warnings, submissionPart, defaultPart, description);
 
     files.forEach(file => {
       const { type, size, name, mimetype } = file;
@@ -450,11 +451,12 @@ export class Bluesky extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<BlueskyNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
 
-    this.validateDescription(problems, warnings, submissionPart, defaultPart);
+    this.validateDescription(problems, warnings, submissionPart, defaultPart, description);
     this.validateReplyToUrl(problems, submissionPart.data.replyToUrl);
     this.validateRating(submissionPart, defaultPart, warnings);
 
@@ -487,12 +489,9 @@ export class Bluesky extends Website {
     warnings: string[],
     submissionPart: SubmissionPart<BlueskyNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): void {
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    const rt = new RichText({ text: description });
+    const rt = new RichText({ text: this.stripTagsShortcut(description) });
     const agent = new BskyAgent({ service: 'https://bsky.social' });
     rt.detectFacets(agent);
 

--- a/electron-app/src/server/websites/custom/custom.service.ts
+++ b/electron-app/src/server/websites/custom/custom.service.ts
@@ -151,6 +151,7 @@ export class Custom extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<DefaultFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/derpibooru/derpibooru.service.ts
+++ b/electron-app/src/server/websites/derpibooru/derpibooru.service.ts
@@ -145,6 +145,7 @@ export class Derpibooru extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<any>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/deviant-art/deviant-art.service.ts
+++ b/electron-app/src/server/websites/deviant-art/deviant-art.service.ts
@@ -351,6 +351,7 @@ export class DeviantArt extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<DeviantArtFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/discord/discord.service.ts
+++ b/electron-app/src/server/websites/discord/discord.service.ts
@@ -138,6 +138,7 @@ export class Discord extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<DiscordFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -160,11 +161,7 @@ export class Discord extends Website {
       }
     });
 
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    if (description.length > this.MAX_CHARS) {
+    if (this.stripTagsShortcut(description).length > this.MAX_CHARS) {
       warnings.push('Max description length allowed is 2,000 characters.');
     }
 
@@ -175,15 +172,12 @@ export class Discord extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<DiscordNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
 
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    if (description.length > this.MAX_CHARS) {
+    if (this.stripTagsShortcut(description).length > this.MAX_CHARS) {
       warnings.push('Max description length allowed is 2,000 characters.');
     }
 

--- a/electron-app/src/server/websites/e621/e621.service.ts
+++ b/electron-app/src/server/websites/e621/e621.service.ts
@@ -154,6 +154,7 @@ export class e621 extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<any>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/fur-affinity/fur-affinity.service.ts
+++ b/electron-app/src/server/websites/fur-affinity/fur-affinity.service.ts
@@ -350,6 +350,7 @@ export class FurAffinity extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<FurAffinityFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/furbooru/furbooru.service.ts
+++ b/electron-app/src/server/websites/furbooru/furbooru.service.ts
@@ -145,6 +145,7 @@ export class Furbooru extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<any>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/furry-network/furry-network.service.ts
+++ b/electron-app/src/server/websites/furry-network/furry-network.service.ts
@@ -442,6 +442,7 @@ export class FurryNetwork extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<FurryNetworkFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -506,6 +507,7 @@ export class FurryNetwork extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<FurryNetworkNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems = [];
     const warnings = [];

--- a/electron-app/src/server/websites/furtastic/furtastic.service.ts
+++ b/electron-app/src/server/websites/furtastic/furtastic.service.ts
@@ -125,6 +125,7 @@ export class Furtastic extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<any>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/hentai-foundry/hentai-foundry.service.ts
+++ b/electron-app/src/server/websites/hentai-foundry/hentai-foundry.service.ts
@@ -160,6 +160,7 @@ export class HentaiFoundry extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<HentaiFoundryFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/inkbunny/inkbunny.service.ts
+++ b/electron-app/src/server/websites/inkbunny/inkbunny.service.ts
@@ -227,6 +227,7 @@ export class Inkbunny extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<InkbunnyFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/itaku/itaku.service.ts
+++ b/electron-app/src/server/websites/itaku/itaku.service.ts
@@ -258,15 +258,12 @@ export class Itaku extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<ItakuFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
 
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    if (description.length > this.MAX_CHARS) {
+    if (this.stripTagsShortcut(description).length > this.MAX_CHARS) {
       problems.push(`Max description length allowed is 5000 characters.`);
     }
 
@@ -302,20 +299,16 @@ export class Itaku extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<ItakuNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
-
-    const description = PlaintextParser.parse(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-      23,
-    );
 
     if (!description) {
       problems.push('Description required');
     }
 
-    if (description.length > this.MAX_CHARS) {
+    if (this.stripTagsShortcut(description).length > this.MAX_CHARS) {
       problems.push(`Max description length allowed is 5000 characters.`);
     }
 

--- a/electron-app/src/server/websites/ko-fi/ko-fi.service.ts
+++ b/electron-app/src/server/websites/ko-fi/ko-fi.service.ts
@@ -168,6 +168,7 @@ export class KoFi extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<KoFiFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/manebooru/manebooru.service.ts
+++ b/electron-app/src/server/websites/manebooru/manebooru.service.ts
@@ -145,6 +145,7 @@ export class Manebooru extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<any>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -229,6 +229,7 @@ export abstract class Megalodon extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<MastodonFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const instanceSettings = this.getInstanceSettings(submissionPart.accountId);
 
@@ -236,14 +237,8 @@ export abstract class Megalodon extends Website {
     const warnings: string[] = [];
     const isAutoscaling: boolean = submissionPart.data.autoScale;
 
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    if (description.length > instanceSettings.maxChars) {
-      warnings.push(
-        `Max description length allowed is ${instanceSettings.maxChars} characters.`,
-      );
+    if (this.stripTagsShortcut(description).length > instanceSettings.maxChars) {
+      warnings.push(`Max description length allowed is ${instanceSettings.maxChars} characters.`);
     } else {
       if (description.toLowerCase().indexOf('{tags}') > -1) {
         this.validateInsertTags(
@@ -321,20 +316,15 @@ export abstract class Megalodon extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<MastodonNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const instanceSettings = this.getInstanceSettings(submissionPart.accountId);
 
     const problems = [];
     const warnings = [];
 
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    if (description.length > instanceSettings.maxChars) {
-      warnings.push(
-        `Max description length allowed is ${instanceSettings.maxChars} characters.`,
-      );
+    if (this.stripTagsShortcut(description).length > instanceSettings.maxChars) {
+      warnings.push(`Max description length allowed is ${instanceSettings.maxChars} characters.`);
     } else {
       this.validateInsertTags(
         warnings,

--- a/electron-app/src/server/websites/misskey/misskey.service.ts
+++ b/electron-app/src/server/websites/misskey/misskey.service.ts
@@ -228,19 +228,16 @@ export class MissKey extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<MissKeyFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
     const isAutoscaling: boolean = submissionPart.data.autoScale;
 
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
     const instanceInfo: MissKeyInstanceInfo = this.getAccountInfo(submissionPart.accountId, INFO_KEY);
     const maxChars = instanceInfo?.configuration?.statuses?.max_characters ?? 500;
 
-    if (description.length > maxChars) {
+    if (this.stripTagsShortcut(description).length > maxChars) {
       warnings.push(
         `Max description length allowed is ${maxChars} characters (for this MissKey client).`,
       );
@@ -310,15 +307,13 @@ export class MissKey extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<MissKeyNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const warnings = [];
-    const description = this.defaultDescriptionParser(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
 
     const instanceInfo: MissKeyInstanceInfo = this.getAccountInfo(submissionPart.accountId, INFO_KEY);
     const maxChars = instanceInfo?.configuration?.statuses?.max_characters ?? 500;
-    if (description.length > maxChars) {
+    if (this.stripTagsShortcut(description).length > maxChars) {
       warnings.push(
         `Max description length allowed is ${maxChars} characters (for this MissKey client).`,
       );

--- a/electron-app/src/server/websites/newgrounds/newgrounds.service.ts
+++ b/electron-app/src/server/websites/newgrounds/newgrounds.service.ts
@@ -364,6 +364,7 @@ export class Newgrounds extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<NewgroundsFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/patreon/patreon.service.ts
+++ b/electron-app/src/server/websites/patreon/patreon.service.ts
@@ -643,6 +643,7 @@ export class Patreon extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<PatreonFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -690,6 +691,7 @@ export class Patreon extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<PatreonNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems = [];
     const warnings = [];

--- a/electron-app/src/server/websites/picarto/picarto.service.ts
+++ b/electron-app/src/server/websites/picarto/picarto.service.ts
@@ -268,6 +268,7 @@ export class Picarto extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<PicartoFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/piczel/piczel.service.ts
+++ b/electron-app/src/server/websites/piczel/piczel.service.ts
@@ -148,6 +148,7 @@ export class Piczel extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<PiczelFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/pillowfort/pillowfort.service.ts
+++ b/electron-app/src/server/websites/pillowfort/pillowfort.service.ts
@@ -196,6 +196,7 @@ export class Pillowfort extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<PillowfortFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/pixiv/pixiv.service.ts
+++ b/electron-app/src/server/websites/pixiv/pixiv.service.ts
@@ -310,6 +310,7 @@ export class Pixiv extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<PixivFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/so-furry/so-furry.service.ts
+++ b/electron-app/src/server/websites/so-furry/so-furry.service.ts
@@ -211,6 +211,7 @@ export class SoFurry extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<SoFurryFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/subscribe-star-adult/subscribe-star-adult.service.ts
+++ b/electron-app/src/server/websites/subscribe-star-adult/subscribe-star-adult.service.ts
@@ -360,6 +360,7 @@ export class SubscribeStarAdult extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<SubscribeStarFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -420,6 +421,7 @@ export class SubscribeStarAdult extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<SubscribeStarNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/subscribe-star/subscribe-star.service.ts
+++ b/electron-app/src/server/websites/subscribe-star/subscribe-star.service.ts
@@ -348,6 +348,7 @@ export class SubscribeStar extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<SubscribeStarFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -408,6 +409,7 @@ export class SubscribeStar extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<SubscribeStarNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/telegram/telegram.service.ts
+++ b/electron-app/src/server/websites/telegram/telegram.service.ts
@@ -513,6 +513,7 @@ export class Telegram extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<TelegramFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -533,11 +534,9 @@ export class Telegram extends Website {
       problems.push('No channel(s) selected.');
     }
 
-    const { description } = TelegramDescription.fromHTML(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-    );
-
-    if (description.length > 4096) {
+    if (
+      TelegramDescription.fromHTML(this.stripTagsShortcut(description)).description.length > 4096
+    ) {
       warnings.push('Max description length allowed is 4,096 characters.');
     }
 

--- a/electron-app/src/server/websites/tumblr/tumblr.service.ts
+++ b/electron-app/src/server/websites/tumblr/tumblr.service.ts
@@ -158,6 +158,7 @@ export class Tumblr extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<TumblrFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
@@ -211,6 +212,7 @@ export class Tumblr extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<TumblrNotificationOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];

--- a/electron-app/src/server/websites/twitter/twitter.service.ts
+++ b/electron-app/src/server/websites/twitter/twitter.service.ts
@@ -142,17 +142,13 @@ export class Twitter extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<TwitterFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];
     const isAutoscaling: boolean = submissionPart.data.autoScale;
 
-    const description = PlaintextParser.parse(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-      23,
-    );
-
-    if (description.length > 280) {
+    if (this.stripTagsShortcut(description).length > 280) {
       warnings.push(
         `Approximated description may surpass 280 character limit (${description.length})`,
       );
@@ -207,15 +203,11 @@ export class Twitter extends Website {
     submission: Submission,
     submissionPart: SubmissionPart<TwitterFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const warnings = [];
 
-    const description = PlaintextParser.parse(
-      FormContent.getDescription(defaultPart.data.description, submissionPart.data.description),
-      23,
-    );
-
-    if (description.length > 280) {
+    if (this.stripTagsShortcut(description).length > 280) {
       warnings.push(
         `Approximated description may surpass 280 character limit (${description.length})`,
       );

--- a/electron-app/src/server/websites/weasyl/weasyl.service.ts
+++ b/electron-app/src/server/websites/weasyl/weasyl.service.ts
@@ -320,6 +320,7 @@ export class Weasyl extends Website {
     submission: FileSubmission,
     submissionPart: SubmissionPart<WeasylFileOptions>,
     defaultPart: SubmissionPart<DefaultOptions>,
+    description: string,
   ): ValidationParts {
     const problems: string[] = [];
     const warnings: string[] = [];


### PR DESCRIPTION
~~**NOTE:** This contains the stuff from #305, since I don't want to put work into fixing conflicts twice from first cherry-picking it out and then rebasing it again later. Either merge that other PR first or do only this one. Look at the individual commits to get a clean diff.~~ Resolved.

The validation functions would get passed the raw description as entered by the user and would make some half-hearted effort to parse them into something sensible, but this completely breaks down in the face of shortcuts like {default}, username shortcuts that get turned into long links etc. Now those functions get the actually parsed description passed to them, the only unresolved shortcut in them being the `{tags}` one, since the length of that is variable and up to the validation function to deal with and tell the user if tags didn't fit.

Since #286, tags insertion is also pretty much busted entirely, since it runs at the wrong time, so it may insert too many tags and then cause an error down the line because the resulting description is too long. That insertion logic has now been moved to the end of the description processing, where it belongs. 