### PR TITLE
Use letter and number classes in tag replacements

### DIFF
--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -182,7 +182,9 @@ export class Bluesky extends Website {
 
   formatTags(tags: string[]) {
     return this.parseTags(
-      tags.map(tag => tag.replace(/[^a-z0-9]/gi, ' ')).map(tag => tag.split(' ').join('')),
+      tags
+        .map(tag => tag.replace(/[^\p{Letter}\p{Number}]/giu, ' '))
+        .map(tag => tag.split(' ').join('')),
       { spaceReplacer: '_' },
     ).map(tag => `#${tag}`);
   }

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -220,7 +220,9 @@ export abstract class Megalodon extends Website {
 
   formatTags(tags: string[]) {
     return this.parseTags(
-      tags.map(tag => tag.replace(/[^a-z0-9]/gi, ' ')).map(tag => tag.split(' ').join('')),
+      tags
+        .map(tag => tag.replace(/[^\p{Letter}\p{Number}]/giu, ' '))
+        .map(tag => tag.split(' ').join('')),
       { spaceReplacer: '_' },
     ).map(tag => `#${tag}`);
   }

--- a/electron-app/src/server/websites/misskey/misskey.service.ts
+++ b/electron-app/src/server/websites/misskey/misskey.service.ts
@@ -213,7 +213,7 @@ export class MissKey extends Website {
   formatTags(tags: string[]) {
     return this.parseTags(
       tags
-        .map(tag => tag.replace(/[^a-z0-9]/gi, ' '))
+        .map(tag => tag.replace(/[^\p{Letter}\p{Number}]/giu, ' '))
         .map(tag =>
           tag
             .split(' ')

--- a/electron-app/src/server/websites/twitter/twitter.service.ts
+++ b/electron-app/src/server/websites/twitter/twitter.service.ts
@@ -61,7 +61,9 @@ export class Twitter extends Website {
 
   formatTags(tags: string[]) {
     return this.parseTags(
-      tags.map(tag => tag.replace(/[^a-z0-9]/gi, ' ')).map(tag => tag.split(' ').join('')),
+      tags
+        .map(tag => tag.replace(/[^\p{Letter}\p{Number}]/giu, ' '))
+        .map(tag => tag.split(' ').join('')),
       { spaceReplacer: '_' },
     ).map(tag => `#${tag}`);
   }


### PR DESCRIPTION
For Mastodon-alikes, Misskey, Bluesky and Twitter. Instead of replacing all non-English letters and non-Arabic digits with nothing and causing those tags to disappear, they now use proper Unicode character classes for letters and numbers that will allow other scripts through while still replacing punctuation and whatnot.