### PR TITLE
Add parent submission field for reply threads

### DIFF
--- a/commons/src/interfaces/submission/default-options.interface.ts
+++ b/commons/src/interfaces/submission/default-options.interface.ts
@@ -8,6 +8,7 @@ export interface DefaultOptions {
   description: DescriptionData;
   rating?: SubmissionRating | string;
   spoilerText?: string;
+  parentId?: string;
   sources: string[];
 }
 

--- a/commons/src/models/default-options.entity.ts
+++ b/commons/src/models/default-options.entity.ts
@@ -34,6 +34,10 @@ export class DefaultOptionsEntity implements DefaultOptions {
   @IsOptional()
   spoilerText?: string;
 
+  @Expose()
+  @IsOptional()
+  parentId?: string;
+
   @IsArray()
   sources: string[];
 

--- a/electron-app/src/server/submission/submission-part/submission-part.service.ts
+++ b/electron-app/src/server/submission/submission-part/submission-part.service.ts
@@ -92,6 +92,18 @@ export class SubmissionPartService {
     return (await this.repository.find({ accountId, submissionId }))[0];
   }
 
+  async getSubmissionDefaultPart(
+    submissionId: string,
+  ): Promise<SubmissionPartEntity<any> | undefined> {
+    return (await this.repository.find({ isDefault: true, submissionId }))[0];
+  }
+
+  async getChildSubmissionIds(parentId: string): Promise<Array<string>> {
+    return (await this.repository.find({ isDefault: true, 'data.parentId': parentId })).map(
+      part => part.submissionId,
+    );
+  }
+
   removeSubmissionPart(id: string): Promise<number> {
     this.logger.log(id, 'Remove Submission Part');
     return this.repository.remove(id);

--- a/electron-app/src/server/submission/submission.controller.ts
+++ b/electron-app/src/server/submission/submission.controller.ts
@@ -61,6 +61,11 @@ export class SubmissionController {
     return this.isTrue(packaged) ? this.service.getAndValidate(id) : this.service.get(id);
   }
 
+  @Get(':id/parent-options')
+  async getParentOptions(@Param('id') id: string) {
+    return this.service.getParentOptions(id);
+  }
+
   @Delete(':id')
   async remove(@Param('id') id: string) {
     return this.service.deleteSubmission(id);

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -696,4 +696,17 @@ export class Bluesky extends Website {
 
     return null;
   }
+
+  override async updateChildPart(
+    part: SubmissionPart<BlueskyFileOptions & BlueskyNotificationOptions>,
+    getSource: () => Promise<string | undefined>,
+  ): Promise<boolean> {
+    const source = await getSource();
+    if (source?.length) {
+      part.data.replyToUrl = source;
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/electron-app/src/server/websites/megalodon/megalodon.service.ts
+++ b/electron-app/src/server/websites/megalodon/megalodon.service.ts
@@ -391,4 +391,16 @@ export abstract class Megalodon extends Website {
     return upload.data.id;
   }
 
+  override async updateChildPart(
+    part: SubmissionPart<MastodonFileOptions & MastodonNotificationOptions>,
+    getSource: () => Promise<string | undefined>,
+  ): Promise<boolean> {
+    const source = await getSource();
+    if (source?.length) {
+      part.data.replyToUrl = source;
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/electron-app/src/server/websites/website.base.ts
+++ b/electron-app/src/server/websites/website.base.ts
@@ -281,4 +281,11 @@ export abstract class Website {
       });
     }
   }
+
+  async updateChildPart(
+    part: SubmissionPart<any>,
+    getSource: () => Promise<string | undefined>,
+  ): Promise<boolean> {
+    return false; // Override me, return true if something changed.
+  }
 }

--- a/ui/src/services/submission.service.ts
+++ b/ui/src/services/submission.service.ts
@@ -65,6 +65,10 @@ export default class SubmissionService {
     return axios.get(`/submission/${id}?packaged=${packaged}`);
   }
 
+  static getSubmissionParentOptions(id: string) {
+    return axios.get(`/submission/${id}/parent-options`);
+  }
+
   static overwriteSubmissionParts(overwrite: SubmissionOverwrite) {
     return axios.post('/submission/overwrite', overwrite);
   }

--- a/ui/src/views/login/AccountInfo.tsx
+++ b/ui/src/views/login/AccountInfo.tsx
@@ -114,6 +114,9 @@ export default class AccountInfo extends React.Component<AccountInfoProps, Accou
             <div>
               {accountInfo.alias}
               <span className="text-link ml-1">
+                <Typography.Text copyable={{ text: this.props.accountInfo._id}}></Typography.Text>
+              </span>
+              <span className="text-link ml-1">
                 <Icon
                   type="edit"
                   onClick={() =>
@@ -129,6 +132,14 @@ export default class AccountInfo extends React.Component<AccountInfoProps, Accou
                 onOk={this.renameAccount}
                 okButtonProps={{ disabled: !this.isRenameValid() }}
               >
+                <p>
+                  Account ID:{' '}
+                  <code>
+                    <Typography.Text copyable={{ text: this.props.accountInfo._id }}>
+                      {this.props.accountInfo._id}
+                    </Typography.Text>
+                  </code>
+                </p>
                 <Form
                   onSubmit={e => {
                     e.preventDefault();

--- a/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
+++ b/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
@@ -135,7 +135,10 @@ export default class DefaultFormSection extends React.Component<
               </Select.Option>
             ))}
           </Select>
-          <p>Supported by {DefaultFormSection.websitesSupportingParentIds}.</p>
+          <p>
+            Used by <code>parent</code> shortcuts and supported by{' '}
+            {DefaultFormSection.websitesSupportingParentIds}.
+          </p>
         </Form.Item>
       </div>
     );

--- a/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
+++ b/ui/src/views/submissions/submission-forms/form-sections/DefaultFormSection.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import _ from 'lodash';
 import { inject } from "mobx-react";
-import { SubmissionPart } from 'postybirb-commons';
+import { SubmissionPart, SubmissionType } from 'postybirb-commons';
 import { SubmissionSectionProps } from '../interfaces/submission-section.interface';
 import TagInput from '../form-components/TagInput';
 import DescriptionInput from '../form-components/DescriptionInput';
-import { Form, Input, Radio } from 'antd';
+import { Form, Icon, Input, Radio, Select } from 'antd';
 import { Submission } from 'postybirb-commons';
 import { DefaultOptions } from 'postybirb-commons';
 import SectionProblems from './SectionProblems';
 import { SubmissionRating } from 'postybirb-commons';
 import { artconomyTagSearchProvider } from '../../../../websites/artconomy/providers';
 import { e621TagSearchProvider } from '../../../../websites/e621/providers';
+import { GenericSelectProps } from '../../../../websites/generic/GenericSelectProps';
+import { WebsiteRegistry } from '../../../../websites/website-registry';
 
 const SEARCH_PROVIDERS = {
   none: undefined,
@@ -23,6 +25,20 @@ const SEARCH_PROVIDERS = {
 export default class DefaultFormSection extends React.Component<
   SubmissionSectionProps<Submission, DefaultOptions>
 > {
+  static websitesSupportingParentIds: string = (() => {
+    const names = WebsiteRegistry.getAllAsArray()
+      .filter(website => website.supportsParentId)
+      .map(website => website.name);
+    if (names.length === 0) {
+      return 'nothing';
+    } else if (names.length === 1) {
+      return names[0];
+    } else {
+      const last = names.pop();
+      return `${names.join(', ')} and ${last}`;
+    }
+  })();
+
   handleChange(fieldName: string, { target }) {
     const part: SubmissionPart<DefaultOptions> = _.cloneDeep(this.props.part);
     part.data[fieldName] = target.value;
@@ -39,6 +55,31 @@ export default class DefaultFormSection extends React.Component<
     const part: SubmissionPart<DefaultOptions> = _.cloneDeep(this.props.part);
     part.data.description = update;
     this.props.onUpdate(part);
+  }
+
+  handleParentIdChange(parentId: string) {
+    const part: SubmissionPart<DefaultOptions> = _.cloneDeep(this.props.part);
+    part.data.parentId = parentId;
+    this.props.onUpdate(part);
+  }
+
+  getParentId(): string {
+    const parentId = this.props.part?.data?.parentId || '';
+    if (parentId?.length && this.props.parentOptions?.find(({ id }) => id === parentId)) {
+      return parentId;
+    } else {
+      return '';
+    }
+  }
+
+  getSubmissionTypeIcon(type: SubmissionType): string {
+    if (type === SubmissionType.FILE) {
+      return 'file';
+    } else if (type === SubmissionType.NOTIFICATION) {
+      return 'notification';
+    } else {
+      return 'question';
+    }
   }
 
   render() {
@@ -80,6 +121,22 @@ export default class DefaultFormSection extends React.Component<
           label="Description"
           hideOverwrite={true}
         />
+        <Form.Item label="Parent Submission">
+          <Select
+            {...GenericSelectProps}
+            className="w-full"
+            value={this.getParentId()}
+            onSelect={this.handleParentIdChange.bind(this)}
+          >
+            <Select.Option value="">None</Select.Option>
+            {(this.props.parentOptions || []).map(({ id, type, title }) => (
+              <Select.Option value={id}>
+                <Icon type={this.getSubmissionTypeIcon(type)}></Icon> {title}
+              </Select.Option>
+            ))}
+          </Select>
+          <p>Supported by {DefaultFormSection.websitesSupportingParentIds}.</p>
+        </Form.Item>
       </div>
     );
   }

--- a/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
+++ b/ui/src/views/submissions/submission-forms/forms/SubmissionEditForm.tsx
@@ -68,6 +68,7 @@ export interface SubmissionEditFormState {
   imageCropperResolve?: (file: File) => void;
   imageCropperReject?: () => void;
   altTexts: { [key: string]: string };
+  parentOptions?: [{ id: string; type: SubmissionType; title: string }];
 }
 
 @inject('loginStatusStore')
@@ -106,8 +107,11 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
   constructor(props: Props) {
     super(props);
     this.id = props.match.params.id;
-    SubmissionService.getSubmission(this.id, true)
-      .then(({ data }) => {
+    Promise.all([
+      SubmissionService.getSubmission(this.id, true),
+      SubmissionService.getSubmissionParentOptions(this.id),
+    ])
+      .then(([{ data }, { data: parentOptions }]) => {
         this.original = _.cloneDeep(data);
         const submissionType: SubmissionType = data.submission.type;
         const altTexts = {};
@@ -125,6 +129,7 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
           postAt: data.submission.schedule.postAt,
           submissionType,
           altTexts,
+          parentOptions,
         });
       })
       .catch(() => {
@@ -810,6 +815,7 @@ class SubmissionEditForm extends React.Component<Props, SubmissionEditFormState>
                   problems={this.state.problems.default}
                   onUpdate={this.onUpdate}
                   submission={this.state.submission!}
+                  parentOptions={this.state.parentOptions}
                 />
               </Form.Item>
 

--- a/ui/src/views/submissions/submission-forms/interfaces/submission-section.interface.ts
+++ b/ui/src/views/submissions/submission-forms/interfaces/submission-section.interface.ts
@@ -1,4 +1,4 @@
-import { SubmissionPart } from 'postybirb-commons';
+import { SubmissionPart, SubmissionType } from 'postybirb-commons';
 import { Submission } from 'postybirb-commons';
 import { DefaultOptions } from 'postybirb-commons';
 import { Problem } from 'postybirb-commons';
@@ -11,4 +11,5 @@ export interface SubmissionSectionProps<T extends Submission, K extends DefaultO
   problems?: Problem;
   submission: T;
   settingsStore?: SettingsStore;
+  parentOptions?: { id: string; type: SubmissionType; title: string }[];
 }

--- a/ui/src/websites/bluesky/Bluesky.tsx
+++ b/ui/src/websites/bluesky/Bluesky.tsx
@@ -20,6 +20,7 @@ export class Bluesky extends WebsiteImpl {
   name: string = 'Bluesky';
   supportsAdditionalFiles: boolean = true;
   supportsTags: boolean = true;
+  supportsParentId: boolean = true;
   loginUrl: string = '';
 
   LoginDialog = (props: LoginDialogProps) => <BlueskyLogin {...props} />;
@@ -79,6 +80,7 @@ BlueskyNotificationOptions
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+        <p>Will be filled with the URL of the parent submission.</p>
       </Form.Item>
     );
     return elements;
@@ -124,6 +126,7 @@ export class BlueskyFileSubmissionForm extends GenericFileSubmissionSection<Blue
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+        <p>Will be filled with the URL of the parent submission.</p>
       </Form.Item>,
     );
     return elements;

--- a/ui/src/websites/interfaces/website.interface.ts
+++ b/ui/src/websites/interfaces/website.interface.ts
@@ -16,6 +16,7 @@ export interface Website {
   name: string;
   supportsAdditionalFiles?: boolean;
   supportsTags?: boolean;
+  supportsParentId?: boolean;
   LoginDialog: (props: LoginDialogProps) => JSX.Element;
   LoginHelp?: (props: LoginDialogProps) => JSX.Element;
   FileSubmissionForm: (props: WebsiteSectionProps<FileSubmission, any>) => JSX.Element;

--- a/ui/src/websites/mastodon/Mastodon.tsx
+++ b/ui/src/websites/mastodon/Mastodon.tsx
@@ -21,6 +21,7 @@ export class Mastodon extends WebsiteImpl {
   name: string = 'Mastodon Instance';
   supportsAdditionalFiles: boolean = true;
   supportsTags: boolean = true;
+  supportsParentId: boolean = true;
   loginUrl: string = '';
 
   LoginDialog = (props: LoginDialogProps) => <MastodonLogin {...props} />;
@@ -94,6 +95,7 @@ class MastodonNotificationSubmissionForm extends GenericSubmissionSection<
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+        <p>Will be filled with the URL of the parent submission.</p>
       </Form.Item>,
     );
     return elements;
@@ -139,6 +141,7 @@ export class MastodonFileSubmissionForm extends GenericFileSubmissionSection<Mas
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+        <p>Will be filled with the URL of the parent submission.</p>
       </Form.Item>,
     );
     return elements;

--- a/ui/src/websites/pleroma/Pleroma.tsx
+++ b/ui/src/websites/pleroma/Pleroma.tsx
@@ -21,6 +21,7 @@ export class Pleroma extends WebsiteImpl {
   name: string = 'Pleroma Instance';
   supportsAdditionalFiles: boolean = true;
   supportsTags: boolean = true;
+  supportsParentId: boolean = true;
   loginUrl: string = '';
 
   LoginDialog = (props: LoginDialogProps) => <PleromaLogin {...props} />;
@@ -93,6 +94,7 @@ class PleromaNotificationSubmissionForm extends GenericSubmissionSection<
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+        <p>Will be filled with the URL of the parent submission.</p>
       </Form.Item>,
     );
     return elements;
@@ -138,6 +140,7 @@ export class PleromaFileSubmissionForm extends GenericFileSubmissionSection<Pler
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
+        <p>Will be filled with the URL of the parent submission.</p>
       </Form.Item>,
     );
     return elements;

--- a/ui/src/websites/website.base.tsx
+++ b/ui/src/websites/website.base.tsx
@@ -19,6 +19,7 @@ export abstract class WebsiteImpl implements Website {
   abstract name: string;
   supportsAdditionalFiles?: boolean = false;
   supportsTags?: boolean = true;
+  supportsParentId?: boolean = false;
 
   LoginDialog(props: LoginDialogProps): JSX.Element {
     return <GenericLoginDialog url={this.loginUrl} {...props} />;


### PR DESCRIPTION
This adds a new "parent submission" field to the default submission section, letting the user pick a submission's parent from a drop-down. After posting a submission, website services get a chance to react to this and manipulate the child's part however they feel is useful.

Currently, this is implemented for Bluesky, Mastodon and Pleroma, which will set the "reply to post URL" field to the source URL of the parent post, removing the necessity to manually copy those over.

Other uses could be implemented if someone feels like it, different websites have various flavors of post relationships that could be handled this way.

The only time the application acts on parent-child relationships is right after a submission has been posted. That means invalid parents that reference removed submissions cause no harm, they're presented to the user as being unassigned. That means we don't need to bother maintaining the validity of these fields when removing submissions. We also don't need to check for circular dependencies, since those circles will break themselves as soon as one submission out of them is posted.

Amendment half a year later: there's also now `{parent:…}` "shortcuts" that get replaced with links to the parent when that is posted, allowing cross-linking.