### PR TITLE
Fix and improve autoscaling behavior

### DIFF
--- a/commons/src/interfaces/settings/settings.interface.ts
+++ b/commons/src/interfaces/settings/settings.interface.ts
@@ -12,6 +12,7 @@ export interface Settings {
   maxPNGSizeCompressionWithAlpha: number;
   maxJPEGQualityCompression: number;
   maxJPEGSizeCompression: number;
+  reduceSizeOverQuality: boolean;
   silentNotification: boolean;
   defaultTagSearchProvider: TagSearchProviders;
   proxy: string;

--- a/electron-app/src/app/settings.ts
+++ b/electron-app/src/app/settings.ts
@@ -21,6 +21,7 @@ const settingDefaults: Settings = {
   maxPNGSizeCompressionWithAlpha: 60,
   maxJPEGQualityCompression: 15,
   maxJPEGSizeCompression: 50,
+  reduceSizeOverQuality: false,
   silentNotification: false,
   defaultTagSearchProvider: 'none',
   proxy: '',

--- a/electron-app/src/server/file-manipulation/file-manipulation.service.ts
+++ b/electron-app/src/server/file-manipulation/file-manipulation.service.ts
@@ -49,6 +49,9 @@ export class FileManipulationService {
           }
 
           if (maxSize < im.getHeight() || maxSize < im.getWidth()) {
+            this.logger.debug(
+              `Resizing to website limit ${maxSize} from ${im.getWidth()}x${im.getHeight()}`,
+            );
             const scaled = await im.resize(maxSize).getData();
             prescale = Math.min(maxSize / im.getWidth(), maxSize / im.getHeight());
             newBuffer = scaled.buffer;
@@ -64,10 +67,19 @@ export class FileManipulationService {
         }
 
         // THEN check for file size limit as before
-        if (!skipRescale) {
+        if (skipRescale) {
+          this.logger.debug('Skip rescale');
+        } else {
           const originalFileSize = buffer.length;
-          if (originalFileSize > targetSize) {
+          if (originalFileSize <= targetSize) {
+            this.logger.debug(
+              `Original file size ${originalFileSize} <= target size ${targetSize}`,
+            );
+          } else {
+            this.logger.debug(`Original file size ${originalFileSize} > target size ${targetSize}`);
+
             if (settings.convertToJPEG) {
+              this.logger.debug('Converting to JPEG');
               im.toJPEG();
             }
 
@@ -93,10 +105,12 @@ export class FileManipulationService {
                   `Unable to successfully scale image down to ${targetSize} bytes from ${originalFileSize} bytes`,
                 );
               } else {
+                this.logger.debug(`Scaled JPEG to size ${jpgScaledBuffer.length}`);
                 newMimeType = 'image/jpeg';
                 newBuffer = jpgScaledBuffer;
               }
             } else {
+              this.logger.debug(`Scaled PNG to size ${pngScaledBuffer.length}`);
               newMimeType = 'image/png';
               newBuffer = pngScaledBuffer;
             }
@@ -134,7 +148,13 @@ export class FileManipulationService {
     prescale: number,
     supportsTransparency: boolean,
   ): Promise<Buffer | null> {
+    this.logger.debug(
+      `scalePNG originalSize ${originalSize}, targetSize ${targetSize}, ` +
+        `prescale ${prescale}, supportsTransparency ${supportsTransparency}`,
+      'PNG COMPRESSION',
+    );
     if (im.getMimeType() === 'image/jpeg') {
+      this.logger.debug('Mime type is JPEG, bailing out', 'PNG COMPRESSION');
       return null;
     }
 
@@ -142,12 +162,18 @@ export class FileManipulationService {
 
     let reductionValue: number = this.settings.getValue<number>('maxPNGSizeCompression');
     const haveTransparency = supportsTransparency && im.hasTransparency();
+    this.logger.debug(`haveTransparency ${haveTransparency}`, 'PNG COMPRESSION');
     if (haveTransparency) {
       reductionValue = this.settings.getValue<number>('maxPNGSizeCompressionWithAlpha');
     } else if (!this.settings.getValue('reduceSizeOverQuality')) {
+      this.logger.debug(
+        'No transparency and quality reduction preferred, bailing out',
+        'PNG COMPRESSION',
+      );
       return null;
     }
 
+    this.logger.debug(`reductionValue ${reductionValue}`, 'PNG COMPRESSION');
     const scaleSize = originalSize / targetSize > 1.5 ? 20 : 10; // try to optimize # of runs for way larger files
     const scaleSteps = this.getSteps(this.applyPrescale(reductionValue, prescale), scaleSize).map(
       step => 1 - step / 100,
@@ -156,11 +182,19 @@ export class FileManipulationService {
     const lastStep = scaleSteps.pop();
     const lastScaled = await im.scale(lastStep).getData(); // check end first to see if we should calculate anything between
     if (lastScaled.buffer.length > targetSize) {
+      this.logger.debug(
+        `lastScaled size ${lastScaled.buffer.length} > ${targetSize}, bailing out`,
+        'PNG COMPRESSION',
+      );
       return null;
     }
 
     for (const scale of scaleSteps) {
       const scaled = await im.scale(scale).getData();
+      this.logger.debug(
+        `Scaled ${scale} to ${scaled.buffer.length} (target ${targetSize})`,
+        'PNG COMPRESSION',
+      );
       if (scaled.buffer.length <= targetSize) {
         this.logger.log(`File Compressed successfully at ${scale} scale`, 'PNG COMPRESSION');
         return scaled.buffer;
@@ -177,17 +211,35 @@ export class FileManipulationService {
     targetSize: number,
     prescale: number,
   ): Promise<Buffer> {
+    this.logger.debug(
+      `scaleJPEG originalSize ${originalSize}, targetSize ${targetSize}, prescale ${prescale}`,
+      'JPEG COMPRESSION',
+    );
     const maxQualityReduction = this.settings.getValue<number>('maxJPEGQualityCompression');
     const maxSizeReduction = this.settings.getValue<number>('maxJPEGSizeCompression');
+    this.logger.debug(
+      `maxQualityReduction ${maxQualityReduction}, maxSizeReduction ${maxSizeReduction}`,
+      'JPEG COMPRESSION',
+    );
 
     im.toJPEG();
 
-    if (!this.settings.getValue('reduceSizeOverQuality')) {
+    if (this.settings.getValue('reduceSizeOverQuality')) {
+      this.logger.debug(
+        `Size reduction preferred, skipping quality reduction attempts`,
+        'JPEG QUALITY COMPRESSION',
+      );
+    } else {
       const minQuality = Math.max(1, Math.round(100 - maxQualityReduction));
+      this.logger.debug(`Quality attempts from 100 to ${minQuality}`, 'JPEG QUALITY COMPRESSION');
       // Quality reduction on its own is pretty fast, so just try every value
       // along the way instead of using some kind of smart scale stepping.
       for (let quality = 100; quality >= minQuality; --quality) {
         const compressed = await im.setQuality(quality).getData();
+        this.logger.debug(
+          `Quality ${quality} to ${compressed.buffer.length} (target ${targetSize})`,
+          'JPEG QUALITY COMPRESSION',
+        );
         if (compressed.buffer.length <= targetSize) {
           this.logger.log(
             `File Compressed successfully at ${quality}% quality`,
@@ -207,6 +259,10 @@ export class FileManipulationService {
 
     const lastStep = scaleSteps[scaleSteps.length - 1];
     const lastScaled = await im.scale(lastStep).getData(); // check end first to see if we should calculate anything between
+    this.logger.debug(
+      `lastScaled size ${lastScaled.buffer.length} (target ${targetSize})`,
+      'JPEG SCALE COMPRESSION',
+    );
     if (lastScaled.buffer.length <= targetSize) {
       if (lastScaled.buffer.length === targetSize) {
         this.logger.log(
@@ -217,6 +273,10 @@ export class FileManipulationService {
       }
       for (const scale of scaleSteps.slice(0, -1)) {
         const scaled = await im.scale(scale).getData();
+        this.logger.debug(
+          `Scaled ${scale} to ${scaled.buffer.length} (target ${targetSize})`,
+          'JPEG SCALE COMPRESSION',
+        );
         if (scaled.buffer.length <= targetSize) {
           this.logger.log(
             `File Compressed successfully at ${scale} scale`,
@@ -242,6 +302,10 @@ export class FileManipulationService {
       for (const quality of qualitySteps) {
         im.toJPEG(quality).scale(scale);
         const scaled = await im.getData();
+        this.logger.debug(
+          `Scaled ${scale} at quality ${quality} to ${scaled.buffer.length} (target ${targetSize})`,
+          'JPEG SCALE AND QUALITY COMPRESSION',
+        );
         if (scaled.buffer.length <= targetSize) {
           this.logger.log(
             `File Compressed successfully at ${quality}% quality and ${scale} scale`,
@@ -273,10 +337,14 @@ export class FileManipulationService {
   // down. In that case, we need to rescale the reduction amount.
   private applyPrescale(reductionValue: number, prescale: number): number {
     if (prescale < 1.0) {
-      return Math.max(
+      const result = Math.max(
         0.0,
         Math.floor(100.0 - ((100.0 - reductionValue) / 100.0 / prescale) * 100.0),
       );
+      this.logger.debug(
+        `Rescaled reduction value ${reductionValue} to ${result} by prescale ${prescale}`,
+      );
+      return result;
     } else {
       return reductionValue;
     }

--- a/electron-app/src/server/file-manipulation/file-manipulation.service.ts
+++ b/electron-app/src/server/file-manipulation/file-manipulation.service.ts
@@ -70,7 +70,7 @@ export class FileManipulationService {
         if (skipRescale) {
           this.logger.debug('Skip rescale');
         } else {
-          const originalFileSize = buffer.length;
+          const originalFileSize = newBuffer.length;
           if (originalFileSize <= targetSize) {
             this.logger.debug(
               `Original file size ${originalFileSize} <= target size ${targetSize}`,

--- a/electron-app/src/server/file-manipulation/file-manipulation.service.ts
+++ b/electron-app/src/server/file-manipulation/file-manipulation.service.ts
@@ -21,6 +21,7 @@ export class FileManipulationService {
     scalingOptions: ScalingOptions,
     settings: {
       convertToJPEG?: boolean;
+      noTransparency?: boolean;
     },
   ): Promise<{ buffer: Buffer; mimetype: string }> {
     let targetSize = scalingOptions.maxSize; // Assumed to be bytes
@@ -75,6 +76,7 @@ export class FileManipulationService {
               originalFileSize,
               targetSize,
               prescale,
+              !settings.noTransparency,
             );
             if (!pngScaledBuffer) {
               const jpgScaledBuffer = await this.scaleJPEG(
@@ -130,6 +132,7 @@ export class FileManipulationService {
     originalSize: number,
     targetSize: number,
     prescale: number,
+    supportsTransparency: boolean,
   ): Promise<Buffer | null> {
     if (im.getMimeType() === 'image/jpeg') {
       return null;
@@ -138,7 +141,8 @@ export class FileManipulationService {
     im.toPNG();
 
     let reductionValue: number = this.settings.getValue<number>('maxPNGSizeCompression');
-    if (im.hasTransparency()) {
+    const haveTransparency = supportsTransparency && im.hasTransparency();
+    if (haveTransparency) {
       reductionValue = this.settings.getValue<number>('maxPNGSizeCompressionWithAlpha');
     } else if (!this.settings.getValue('reduceSizeOverQuality')) {
       return null;

--- a/electron-app/src/server/submission/parser/parser.service.ts
+++ b/electron-app/src/server/submission/parser/parser.service.ts
@@ -42,7 +42,12 @@ export class ParserService {
     private readonly fileManipulator: FileManipulationService,
     websitesService: WebsitesService,
   ) {
-    this.descriptionParser = new DescriptionParser(customShortcuts, websitesService, settings, this);
+    this.descriptionParser = new DescriptionParser(
+      customShortcuts,
+      websitesService,
+      settings,
+      this,
+    );
   }
 
   public async parse(
@@ -223,7 +228,10 @@ export class ParserService {
           file.buffer,
           file.mimetype,
           scaleOptions,
-          { convertToJPEG: scaleOptions.converToJPEG },
+          {
+            convertToJPEG: scaleOptions.converToJPEG,
+            noTransparency: scaleOptions.noTransparency,
+          },
         );
         if (mimetype !== file.mimetype) {
           record.file.options.filename = this.fixFileExtension(mimetype, file.name);

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -113,6 +113,7 @@ export class Bluesky extends Website {
       maxHeight: 2000,
       maxWidth: 2000,
       maxSize: 1000000,
+      noTransparency: true, // Bsky doesn't support alpha transparency.
     };
   }
 

--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -112,7 +112,7 @@ export class Bluesky extends Website {
       // Yes they are this lame: https://github.com/bluesky-social/social-app/blob/main/src/lib/constants.ts
       maxHeight: 2000,
       maxWidth: 2000,
-      maxSize: FileSize.MBtoBytes(0.9),
+      maxSize: 1000000,
     };
   }
 

--- a/electron-app/src/server/websites/interfaces/scaling-options.interface.ts
+++ b/electron-app/src/server/websites/interfaces/scaling-options.interface.ts
@@ -3,4 +3,5 @@ export interface ScalingOptions {
   maxHeight?: number;
   maxWidth?: number;
   converToJPEG?: boolean;
+  noTransparency?: boolean;
 }

--- a/ui/src/stores/settings.store.ts
+++ b/ui/src/stores/settings.store.ts
@@ -16,6 +16,7 @@ export class SettingsStore {
     maxPNGSizeCompressionWithAlpha: 25,
     maxJPEGQualityCompression: 10,
     maxJPEGSizeCompression: 30,
+    reduceSizeOverQuality: false,
     silentNotification: false,
     defaultTagSearchProvider: 'none',
     proxy: '',

--- a/ui/src/views/settings/SettingsView.tsx
+++ b/ui/src/views/settings/SettingsView.tsx
@@ -166,7 +166,9 @@ export default class SettingsView extends React.Component<Props> {
               </Form.Item>
               <Form.Item
                 label="Max Image Quality Reduction"
-                extra="Size reduction is attempted before quality reduction."
+                extra={`An image would be reduced down to a ${
+                  100 - settings.maxJPEGQualityCompression
+                }% quality JPEG at most.`}
               >
                 <InputNumber
                   min={0}
@@ -181,6 +183,15 @@ export default class SettingsView extends React.Component<Props> {
                   }
                 />
               </Form.Item>
+            </Form.Item>
+            <Form.Item
+              label="Reduce Size Before Quality"
+              extra="Enabling this will scale images smaller before using lossy JPEG compression. Images with opacity will always attempt scaling before resorting to JPEG."
+            >
+              <Switch
+                checked={settings.reduceSizeOverQuality}
+                onChange={value => this.updateSetting('reduceSizeOverQuality', value)}
+              />
             </Form.Item>
           </Collapse.Panel>
           <Collapse.Panel header="Theme" key="theme">


### PR DESCRIPTION
A few things in here, check the individual commits for more details. The main issue here is that when you post to Bsky, the image gets scaled to a dinky 1000x1000 size, which is a) wrong, because it exceeds the maximum scale amount I set and b) bad, because it could just use a pretty good quality JPEG instead and not lose any size.

So this PR does a few things in that regard.

It takes the maximum scale amount set by the user relative to the *original* image size, not the size after rescaling the image according to website limits. Presumably this was the intended behavior to begin with, so this is just a bugfix.

Maybe somewhat controversially, it now prefers quality reduction over size reduction by default, at least for images that don't have an alpha channel. Reducing JPEG quality is notably faster than trying a bunch of resizing and, in my opinion, gives better visual quality than having a smaller image. It's a preference, so users that don't want this can still disable it.

It corrects the maximum image size in bytes for Bsky. It was set to 0.9 MiB, but it's really 1000000 bytes. Only a difference of 55 KiB, but hey.

Finally, it marks Bsky as not supporting alpha. If a website sets this flag, the file munger will act accordingly resizing the image as if it didn't have alpha and converting to JPEG more eagerly.

I'll be marking this as tentative, since it could use some feedback and testing first.