### PR TITLE
fix: allow Bluesky Posts without alt text

### DIFF
--- a/electron-app/src/server/websites/bluesky/bluesky.service.ts
+++ b/electron-app/src/server/websites/bluesky/bluesky.service.ts
@@ -126,14 +126,13 @@ export class Bluesky extends Website {
   private async uploadEmbeds(
     agent: BskyAgent,
     files: PostFileRecord[],
-    fallbackAltText?: string,
   ): Promise<AppBskyEmbedImages.Main | AppBskyEmbedVideo.Main> {
     // Bluesky supports either images or a video as an embed
 
     if (this.countFileTypes(files).videos === 0) {
       const uploadedImages: AppBskyEmbedImages.Image[] = [];
       for (const file of files.slice(0, this.MAX_MEDIA)) {
-        const altText = file.altText || fallbackAltText;
+        const altText = file.altText || '';
         const ref = await this.uploadImage(agent, file.file);
 
         uploadedImages.push({
@@ -153,7 +152,7 @@ export class Bluesky extends Website {
     } else {
       for (const file of files) {
         if (file.type == FileSubmissionType.VIDEO) {
-          const altText = file.altText || fallbackAltText;
+          const altText = file.altText || '';
           this.checkVideoUploadLimits(agent);
           const ref = await this.uploadVideo(agent, file.file);
           return {
@@ -364,7 +363,7 @@ export class Bluesky extends Website {
     const reply = await this.getReplyRef(agent, data.options.replyToUrl);
 
     const files = [data.primary, ...data.additional];
-    const embeds = await this.uploadEmbeds(agent, files, data.options.altText);
+    const embeds = await this.uploadEmbeds(agent, files);
 
     let labelsRecord: ComAtprotoLabelDefs.SelfLabels | undefined;
     if (data.options.label_rating) {
@@ -519,12 +518,6 @@ export class Bluesky extends Website {
         f => !f.ignoredAccounts!.includes(submissionPart.accountId),
       ),
     ];
-    if (!submissionPart.data.altText && files.some(f => !f.altText)) {
-      problems.push(
-        'Bluesky currently always requires alt text to be provided, ' +
-          'even if your settings say otherwise. This is a bug on their side.',
-      );
-    }
 
     this.validateRating(submissionPart, defaultPart, warnings);
 

--- a/ui/src/websites/bluesky/Bluesky.tsx
+++ b/ui/src/websites/bluesky/Bluesky.tsx
@@ -73,8 +73,8 @@ BlueskyNotificationOptions
           <Select.Option value={''}>Everybody</Select.Option>
           <Select.Option value={'nobody'}>Nobody</Select.Option>
           <Select.Option value={'mention'}>Mentioned Users</Select.Option>
-          <Select.Option value={'following'}>Followed Users</Select.Option>   
-          <Select.Option value={'mention,following'}>Mentioned & Followed Users</Select.Option>     
+          <Select.Option value={'following'}>Followed Users</Select.Option>
+          <Select.Option value={'mention,following'}>Mentioned & Followed Users</Select.Option>
         </Select>
       </Form.Item>,
       <Form.Item label="Reply To Post URL">
@@ -112,16 +112,10 @@ export class BlueskyFileSubmissionForm extends GenericFileSubmissionSection<Blue
         <Select.Option value={''}>Everybody</Select.Option>
         <Select.Option value={'nobody'}>Nobody</Select.Option>
         <Select.Option value={'mention'}>Mentioned Users</Select.Option>
-        <Select.Option value={'following'}>Followed Users</Select.Option>   
-        <Select.Option value={'mention,following'}>Mentioned & Followed Users</Select.Option>     
-      </Select>                  
+        <Select.Option value={'following'}>Followed Users</Select.Option>
+        <Select.Option value={'mention,following'}>Mentioned & Followed Users</Select.Option>
+      </Select>
     </Form.Item>,
-      <Form.Item label="Fallback Alt Text">
-        <Input
-          value={data.altText}
-          onChange={this.handleValueChange.bind(this, 'altText')}
-        />
-      </Form.Item>,
       <Form.Item label="Reply To Post URL">
         <Input value={data.replyToUrl} onChange={this.handleValueChange.bind(this, 'replyToUrl')} />
       </Form.Item>,


### PR DESCRIPTION
Sending '' as alt text is valid and the official solution (https://github.com/bluesky-social/social-app/blob/fa2072cefa0379fd1ea36ad109b8d24721838958/jest/test-pds.ts#L251)

I tested it on my end and it'll send images just fine without alt texts.