### PR TITLE
Aryion PDF support

### DIFF
--- a/ui/src/websites/aryion/Aryion.tsx
+++ b/ui/src/websites/aryion/Aryion.tsx
@@ -26,7 +26,7 @@ export class Aryion extends WebsiteImpl {
   );
 
   supportsTextType(type: string): boolean {
-    return ['text/plain'].includes(type);
+    return ['text/plain', 'application/pdf', 'text/pdf'].includes(type);
   }
 }
 


### PR DESCRIPTION
At some point Aryion added support for a few different file types. This pull request allows Postybirb to submit PDFs. It also allows Postybirb to disregard warnings from submissions. More details about that in the code, since it may or may not be the approach that you'd like to take. >w<

Aryion supports other file types that I have not added support for: docx, rtf, etc.. Adding support for them would likely be straightforward (just adding them to the supported files lists), but I haven't had time to test to make sure that they're all working.