### PR TITLE
Add option for PillowFort - only logged in users

### DIFF
--- a/ui/src/websites/pillowfort/Pillowfort.tsx
+++ b/ui/src/websites/pillowfort/Pillowfort.tsx
@@ -18,6 +18,7 @@ const privacyOptions = {
   followers: 'Followers',
   mutuals: 'Mutuals',
   private: 'Private',
+  users: 'Logged-in users',
 };
 
 export class Pillowfort extends WebsiteImpl {


### PR DESCRIPTION
Adds the ability for posts to pillowfort to be marked for only visible to logged in users (looked to be the only option missing)