### PR TITLE
Fix for Discord Backwards Compatibility and Typo

### DIFF
--- a/electron-app/src/server/websites/discord/discord.service.ts
+++ b/electron-app/src/server/websites/discord/discord.service.ts
@@ -56,7 +56,11 @@ export class Discord extends Website {
         requestOptions: { json: true },
       });
 
-      this.storeAccountInformation(data._id, 'serverBoostLevel', webhookData.serverBoostLevel);
+	  const boostLevel = webhookData.serverBoostLevel;
+	  if (boostLevel == null || boostLevel < 0 || boostLevel >= this.SERVER_BOOST_LIMITS.length) {
+	  	webhookData.serverBoostLevel = 0;
+	  }
+	  this.storeAccountInformation(data._id, 'serverBoostLevel', webhookData.serverBoostLevel);
 
       if (!channel.error && channel.body.id) {
         status.loggedIn = true;
@@ -169,7 +173,7 @@ export class Discord extends Website {
       }
       if (FileSize.MBtoBytes(filesizeLimit) < size) {
         warnings.push(
-          `$The selected Discord boost level requires files to be ${filesizeLimit}MB or less.`,
+          `The selected Discord boost level requires files to be ${filesizeLimit}MB or less.`,
         );
       }
     });

--- a/electron-app/src/server/websites/discord/discord.service.ts
+++ b/electron-app/src/server/websites/discord/discord.service.ts
@@ -56,10 +56,10 @@ export class Discord extends Website {
         requestOptions: { json: true },
       });
 
-	  const boostLevel = webhookData.serverBoostLevel;
-	  if (boostLevel == null || boostLevel < 0 || boostLevel >= this.SERVER_BOOST_LIMITS.length) {
-	  	webhookData.serverBoostLevel = 0;
-	  }
+      const boostLevel = webhookData.serverBoostLevel;
+      if (boostLevel == null || boostLevel < 0 || boostLevel >= this.SERVER_BOOST_LIMITS.length) {
+        webhookData.serverBoostLevel = 0;
+      }
 	  this.storeAccountInformation(data._id, 'serverBoostLevel', webhookData.serverBoostLevel);
 
       if (!channel.error && channel.body.id) {

--- a/electron-app/src/server/websites/discord/discord.service.ts
+++ b/electron-app/src/server/websites/discord/discord.service.ts
@@ -60,7 +60,7 @@ export class Discord extends Website {
       if (boostLevel == null || boostLevel < 0 || boostLevel >= this.SERVER_BOOST_LIMITS.length) {
         webhookData.serverBoostLevel = 0;
       }
-	  this.storeAccountInformation(data._id, 'serverBoostLevel', webhookData.serverBoostLevel);
+      this.storeAccountInformation(data._id, 'serverBoostLevel', webhookData.serverBoostLevel);
 
       if (!channel.error && channel.body.id) {
         status.loggedIn = true;


### PR DESCRIPTION
For Discord accounts created in version <= 3.1.60, the server boost level is null when version 3.1.61 attempts to read it to determine the appropriate file size.

This PR improves backwards compatibility with checking the boost level. If null, or some other unexpected value, it will be reset to boost level 0 (the default).

Also fixes an erroneous `$` character in a warning message.